### PR TITLE
feat(#52): add a TTL period to deployed jobs

### DIFF
--- a/charts/locust-k8s-operator/templates/deployment.yaml
+++ b/charts/locust-k8s-operator/templates/deployment.yaml
@@ -62,6 +62,10 @@ spec:
                   key: {{ .Values.config.loadGenerationPods.kafka.acl.secret.passwordKey }}
             {{- end }}
 
+            # Load generation job config
+            - name: JOB_TTL_SECONDS_AFTER_FINISHED
+              value: {{ .Values.config.loadGenerationJobs.ttlSecondsAfterFinished | quote }}
+
             # Load generation resource config
             - name: POD_CPU_REQUEST
               value: {{ .Values.config.loadGenerationPods.resource.cpuRequest | quote }}

--- a/charts/locust-k8s-operator/values.yaml
+++ b/charts/locust-k8s-operator/values.yaml
@@ -1,6 +1,6 @@
 # Default values for locust-k8s-operator.
 
-# Geneal
+# General
 appPort: 8080
 
 # Deployment
@@ -67,6 +67,10 @@ tolerations: []
 affinity: {}
 
 config:
+  loadGenerationJobs:
+    # Either leave empty or use an empty string to avoid setting this option
+    ttlSecondsAfterFinished: ""
+
   loadGenerationPods:
     resource:
       cpuRequest: 250m

--- a/docs/advanced_topics.md
+++ b/docs/advanced_topics.md
@@ -131,6 +131,35 @@ closely [Kubernetes native definition](https://kubernetes.io/docs/concepts/sched
         ...
     ```
 
+## Automatic Cleanup for Finished Master and Worker Jobs
 
+Once load tests finish, master and worker jobs remain available in Kubernetes. 
+You can set up a time-to-live (TTL) value in the operator's Helm chart, so that 
+kubernetes jobs are eligible for cascading removal once the TTL expires. This means 
+that Master and Worker jobs and their dependent objects (e.g., pods) will be deleted.
 
+Note that setting up a TTL will not delete `LocustTest` or `ConfigMap` resources.
 
+To set a TTL value, override the key `ttlSecondsAfterFinished` in `values.yaml`:
+
+=== ":octicons-file-code-16: `values.yaml`"
+
+    ```yaml
+    ...
+    config:
+      loadGenerationJobs:
+        # Either leave empty or use an empty string to avoid setting this option
+        ttlSecondsAfterFinished: 3600
+    ...
+    ```
+
+You can also use Helm's CLI arguments: `helm install ... --set config.loadGenerationJobs.ttlSecondsAfterFinished=0`.
+
+Read more about the `ttlSecondsAfterFinished` parameter in Kubernetes's [official documentation](https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/).
+
+### Kubernetes Support for `ttlSecondsAfterFinished`
+
+Support for parameter `ttlSecondsAfterFinished` was added in Kubernetes v1.12. 
+In case you're deploying the locust operator to a Kubernetes cluster that does not 
+support `ttlSecondsAfterFinished`, you may leave the Helm key empty or use an empty 
+string. In this case, job definitions will not include the parameter. 

--- a/docs/helm_deploy.md
+++ b/docs/helm_deploy.md
@@ -30,7 +30,7 @@ In order to deploy using helm, follow the below steps:
 
 [//]: # (Resources urls)
 
-[crd-locusttest.yaml]: https://github.com/AbdelrhmanHamouda/locust-k8s-operator/blob/master/charts/locust-k8s-operator/templates/crd-locusttest.yaml
+[crd-locusttest.yaml]: https://github.com/AbdelrhmanHamouda/locust-k8s-operator/blob/master/charts/locust-k8s-operator/crds/locust-test-crd.yaml
 
 [serviceaccount-and-roles.yaml]: https://github.com/AbdelrhmanHamouda/locust-k8s-operator/blob/master/charts/locust-k8s-operator/templates/serviceaccount-and-roles.yaml
 

--- a/src/main/java/com/locust/operator/controller/config/SysConfig.java
+++ b/src/main/java/com/locust/operator/controller/config/SysConfig.java
@@ -4,6 +4,7 @@ import io.micronaut.context.annotation.Property;
 import jakarta.inject.Singleton;
 import lombok.Getter;
 import lombok.ToString;
+import org.apache.commons.lang3.math.NumberUtils;
 
 @Getter
 @ToString
@@ -27,6 +28,16 @@ public class SysConfig {
     @Property(name = "config.load-generation-pods.kafka.sasl.jaas.config")
     private String kafkaSaslJaasConfig;
 
+    // * Generated job characteristics
+    /**
+     * We use Object here to prevent automatic conversion from null to 0.
+     * <p>
+     * See {@link #getTtlSecondsAfterFinished()} for understanding how the
+     * value is converted to an integer.
+     */
+    @Property(name = "config.load-generation-jobs.ttl-seconds-after-finished")
+    private Object ttlSecondsAfterFinished;
+
     // * Generated pod characteristics
     @Property(name = "config.load-generation-pods.resource.cpu-request")
     private String podCpuRequest;
@@ -46,4 +57,27 @@ public class SysConfig {
     @Property(name = "config.load-generation-pods.taintTolerations.enableCrInjection")
     private boolean tolerationsCrInjectionEnabled;
 
+    /**
+     * Value configured for setting Kubernetes Jobs' ttlSecondsAfterFinished property.
+     * This method will try to convert the value to an integer or fail and report invalid values.
+     * {@code null} or empty strings will result in a {@code null} return.
+     *
+     * @return either {@code null} or an integer value greater than or equal to 0
+     */
+    public Integer getTtlSecondsAfterFinished() {
+        final String stringValue = String.valueOf(this.ttlSecondsAfterFinished);
+
+        if (NumberUtils.isDigits(stringValue)) {
+            return Integer.parseInt(stringValue);
+        } else if (stringValue.isEmpty()) {
+            return null;
+        } else {
+            throw new IllegalArgumentException(
+                String.format(
+                    "Invalid value '%s' for property ttl-seconds-after-finished",
+                    stringValue
+                )
+            );
+        }
+    }
 }

--- a/src/main/java/com/locust/operator/controller/dto/LoadGenerationNode.java
+++ b/src/main/java/com/locust/operator/controller/dto/LoadGenerationNode.java
@@ -22,6 +22,7 @@ public class LoadGenerationNode {
     private Map<String, String> annotations;
     private LocustTestAffinity affinity;
     private List<LocustTestToleration> tolerations;
+    private Integer ttlSecondsAfterFinished;
     private List<String> command;
     private OperationalMode operationalMode;
     private String image;

--- a/src/main/java/com/locust/operator/controller/utils/LoadGenHelpers.java
+++ b/src/main/java/com/locust/operator/controller/utils/LoadGenHelpers.java
@@ -12,7 +12,6 @@ import jakarta.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.validation.constraints.NotNull;
-
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -62,6 +61,7 @@ public class LoadGenHelpers {
             constructNodeAnnotations(resource, mode),
             getNodeAffinity(resource),
             getPodToleration(resource),
+            getTtlSecondsAfterFinished(),
             constructNodeCommand(resource, mode),
             mode,
             getNodeImage(resource),
@@ -69,6 +69,10 @@ public class LoadGenHelpers {
             getNodePorts(resource, mode),
             getConfigMap(resource));
 
+    }
+
+    private Integer getTtlSecondsAfterFinished() {
+        return this.config.getTtlSecondsAfterFinished();
     }
 
     private List<LocustTestToleration> getPodToleration(LocustTest resource) {

--- a/src/main/java/com/locust/operator/controller/utils/resource/manage/ResourceCreationHelpers.java
+++ b/src/main/java/com/locust/operator/controller/utils/resource/manage/ResourceCreationHelpers.java
@@ -131,6 +131,7 @@ public class ResourceCreationHelpers {
 
         // * Job Spec configuration
         JobSpec jobSpec = new JobSpecBuilder()
+            .withTtlSecondsAfterFinished(nodeConfig.getTtlSecondsAfterFinished())
 
             // Pods count
             // Setting the `Parallelism` attribute will result in k8s deploying pods to match the requested value

--- a/src/main/java/com/locust/operator/controller/utils/resource/manage/ResourceDeletionManager.java
+++ b/src/main/java/com/locust/operator/controller/utils/resource/manage/ResourceDeletionManager.java
@@ -30,7 +30,6 @@ public class ResourceDeletionManager {
 
             val namespace = crdInstance.getMetadata().getNamespace();
             val resourceName = loadGenHelpers.constructNodeName(crdInstance, mode);
-
             log.info("Deleting Job for: {} in namespace: {}", crdInstance.getMetadata().getName(), namespace);
             return Optional.ofNullable(client.batch().v1().jobs().inNamespace(namespace).withName(resourceName).delete());
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,6 +40,8 @@ config:
     resyncPeriod: 1m
   k8s:
     namespace: ${K8S_NAMESPACE:default}
+  load-generation-jobs:
+    ttl-seconds-after-finished: ${JOB_TTL_SECONDS_AFTER_FINISHED}
   load-generation-pods:
     affinity:
       enableCrInjection: ${ENABLE_AFFINITY_CR_INJECTION:false}

--- a/src/test/java/com/locust/operator/controller/TestFixtures.java
+++ b/src/test/java/com/locust/operator/controller/TestFixtures.java
@@ -32,7 +32,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 @NoArgsConstructor(access = PRIVATE)
 public class TestFixtures {
 
-    public static final String CRD_FILE_PATH = "charts/locust-k8s-operator/templates/crd-locusttest.yaml";
+    public static final String CRD_FILE_PATH = "charts/locust-k8s-operator/crds/locust-test-crd.yaml";
     public static final String DEFAULT_API_VERSION = GROUP + "/" + VERSION;
     public static final String KIND = "LocustTest";
     public static final String DEFAULT_SEED_COMMAND = "--locustfile src/demo.py";

--- a/src/test/java/com/locust/operator/controller/utils/TestFixtures.java
+++ b/src/test/java/com/locust/operator/controller/utils/TestFixtures.java
@@ -58,6 +58,7 @@ public class TestFixtures {
     public static final String MOCK_POD_MEM = "1024Mi";
     public static final String MOCK_POD_CPU = "1000m";
     public static final String MOCK_POD_EPHEMERAL_STORAGE = "50M";
+    public static final Integer MOCK_TTL_SECONDS_AFTER_FINISHED = 60;
     public static final Map<String, String> DEFAULT_MASTER_LABELS = Map.of("role", "master");
     public static final Map<String, String> DEFAULT_WORKER_LABELS = Map.of("role", "worker");
     public static final Map<String, String> DEFAULT_MASTER_ANNOTATIONS = Map.of("locust.io/role", "master");
@@ -76,10 +77,13 @@ public class TestFixtures {
 
         List<Integer> expectedPortList = mode.equals(MASTER) ? DEFAULT_MASTER_PORT_LIST : DEFAULT_WORKER_PORT_LIST;
 
+        Integer expectedTtlSecondsAfterFinished = MOCK_TTL_SECONDS_AFTER_FINISHED;
+
         assertSoftly(softly -> {
             softly.assertThat(generatedNodeConfig.getName()).contains(expectedConfigName);
             softly.assertThat(generatedNodeConfig.getLabels()).isEqualTo(expectedLabels);
             softly.assertThat(generatedNodeConfig.getAnnotations()).isEqualTo(expectedAnnotations);
+            softly.assertThat(generatedNodeConfig.getTtlSecondsAfterFinished()).isEqualTo(expectedTtlSecondsAfterFinished);
             softly.assertThat(generatedNodeConfig.getOperationalMode()).isEqualTo(mode);
             softly.assertThat(generatedNodeConfig.getPorts()).isEqualTo(expectedPortList);
             softly.assertThat(generatedNodeConfig.getReplicas()).isEqualTo(expectedReplicas);
@@ -97,6 +101,24 @@ public class TestFixtures {
             .replicas(mode.equals(MASTER) ? MASTER_REPLICA_COUNT : REPLICAS)
             .ports(mode.equals(MASTER) ? DEFAULT_MASTER_PORT_LIST : DEFAULT_WORKER_PORT_LIST)
             .build();
+
+        log.debug("Created node configuration: {}", nodeConfig);
+        return nodeConfig;
+    }
+
+    public static LoadGenerationNode prepareNodeConfigWithTtlSecondsAfterFinished(
+        String nodeName, OperationalMode mode, Integer ttlSecondsAfterFinished) {
+        var nodeConfig = LoadGenerationNode.builder()
+                .name(nodeName)
+                .labels(mode.equals(MASTER) ? DEFAULT_MASTER_LABELS : DEFAULT_WORKER_LABELS)
+                .annotations(mode.equals(MASTER) ? DEFAULT_MASTER_ANNOTATIONS : DEFAULT_WORKER_ANNOTATIONS)
+                .ttlSecondsAfterFinished(ttlSecondsAfterFinished)
+                .command(List.of(DEFAULT_SEED_COMMAND.split(CONTAINER_ARGS_SEPARATOR)))
+                .operationalMode(mode)
+                .image(DEFAULT_TEST_IMAGE)
+                .replicas(mode.equals(MASTER) ? MASTER_REPLICA_COUNT : REPLICAS)
+                .ports(mode.equals(MASTER) ? DEFAULT_MASTER_PORT_LIST : DEFAULT_WORKER_PORT_LIST)
+                .build();
 
         log.debug("Created node configuration: {}", nodeConfig);
         return nodeConfig;
@@ -139,6 +161,15 @@ public class TestFixtures {
             softly.assertThat(resourceList.getItems().get(0).getMetadata().getName()).isEqualTo(nodeName);
         });
 
+    }
+
+    public static void assertK8sTtlSecondsAfterFinished(JobList jobList, Integer ttlSecondsAfterFinished) {
+        jobList.getItems().forEach(job -> {
+            val actualTtlSecondsAfterFinished = job.getSpec().getTtlSecondsAfterFinished();
+            assertSoftly(softly -> {
+                softly.assertThat(actualTtlSecondsAfterFinished).isEqualTo(ttlSecondsAfterFinished);
+            });
+        });
     }
 
     public static void assertK8sNodeAffinity(LoadGenerationNode nodeConfig, JobList jobList, String k8sNodeLabelKey) {
@@ -238,6 +269,10 @@ public class TestFixtures {
             .thenReturn(MOCK_POD_CPU);
         when(mockedConfInstance.getPodEphemeralStorageRequest())
             .thenReturn(MOCK_POD_EPHEMERAL_STORAGE);
+
+        // Job characteristics
+        when(mockedConfInstance.getTtlSecondsAfterFinished())
+            .thenReturn(MOCK_TTL_SECONDS_AFTER_FINISHED);
 
         // Resource limit
         when(mockedConfInstance.getPodMemLimit())

--- a/src/test/java/com/locust/operator/controller/utils/resource/manage/ResourceCreationManagerTests.java
+++ b/src/test/java/com/locust/operator/controller/utils/resource/manage/ResourceCreationManagerTests.java
@@ -18,11 +18,13 @@ import static com.locust.operator.controller.dto.OperationalMode.MASTER;
 import static com.locust.operator.controller.utils.TestFixtures.assertK8sNodeAffinity;
 import static com.locust.operator.controller.utils.TestFixtures.assertK8sResourceCreation;
 import static com.locust.operator.controller.utils.TestFixtures.assertK8sTolerations;
+import static com.locust.operator.controller.utils.TestFixtures.assertK8sTtlSecondsAfterFinished;
 import static com.locust.operator.controller.utils.TestFixtures.containerEnvironmentMap;
 import static com.locust.operator.controller.utils.TestFixtures.executeWithK8sMockServer;
 import static com.locust.operator.controller.utils.TestFixtures.prepareNodeConfig;
 import static com.locust.operator.controller.utils.TestFixtures.prepareNodeConfigWithNodeAffinity;
 import static com.locust.operator.controller.utils.TestFixtures.prepareNodeConfigWithTolerations;
+import static com.locust.operator.controller.utils.TestFixtures.prepareNodeConfigWithTtlSecondsAfterFinished;
 import static org.mockito.Mockito.when;
 
 @Slf4j
@@ -97,6 +99,52 @@ public class ResourceCreationManagerTests {
     }
 
     @Test
+    @DisplayName("Functional: Create a kubernetes Job with Default TTL Seconds After Finished")
+    void createJobWithDefaultTtlSecondsAfterFinishedTest() {
+
+        // * Setup
+        val namespace = "ttl-ns";
+        val nodeName = "ttl-demo-test";
+        val resourceName = "ttl.demo-test";
+        final Integer defaultTtlSecondsAfterFinished = null;
+        val nodeConfig = prepareNodeConfigWithTtlSecondsAfterFinished(nodeName, MASTER, defaultTtlSecondsAfterFinished);
+
+        // * Act
+        executeWithK8sMockServer(k8sServerUrl, () -> CreationManager.createJob(nodeConfig, namespace, resourceName));
+
+        // Get All Jobs created by the method
+        val jobList = testClient.batch().v1().jobs().inNamespace(namespace).list();
+        log.debug("Acquired Job list: {}", jobList);
+
+        // * Assert
+        assertK8sTtlSecondsAfterFinished(jobList, defaultTtlSecondsAfterFinished);
+
+    }
+
+    @Test
+    @DisplayName("Functional: Create a kubernetes Job with TTL Seconds After Finished")
+    void createJobWithTtlSecondsAfterFinishedTest() {
+
+        // * Setup
+        val namespace = "ttl-ns";
+        val nodeName = "ttl-demo-test";
+        val resourceName = "ttl.demo-test";
+        val ttlSecondsAfterFinished = Integer.valueOf(120);
+        val nodeConfig = prepareNodeConfigWithTtlSecondsAfterFinished(nodeName, MASTER, ttlSecondsAfterFinished);
+
+        // * Act
+        executeWithK8sMockServer(k8sServerUrl, () -> CreationManager.createJob(nodeConfig, namespace, resourceName));
+
+        // Get All Jobs created by the method
+        val jobList = testClient.batch().v1().jobs().inNamespace(namespace).list();
+        log.debug("Acquired Job list: {}", jobList);
+
+        // * Assert
+        assertK8sTtlSecondsAfterFinished(jobList, ttlSecondsAfterFinished);
+
+    }
+
+    @Test
     @DisplayName("Functional: Create a kubernetes Job with Node Affinity")
     void createJobWithNodeAffinityTest() {
 
@@ -120,7 +168,7 @@ public class ResourceCreationManagerTests {
         assertK8sNodeAffinity(nodeConfig, jobList, k8sNodeLabelKey);
 
     }
-    
+
     @Test
     @DisplayName("Functional: Create a kubernetes Job with Tolerations and Toleration Operator set to Equal")
     void createJobWithTolerationsAndOperatorEqualTest() {


### PR DESCRIPTION
This pull request implements the feature I proposed in https://github.com/AbdelrhmanHamouda/locust-k8s-operator/issues/52

I've added some documentation in the advanced topics page.

One caveat of this implementation is that Kubernetes's TTL controller doesn't support custom resources. So, setting the `ttlSecondsAfterFinished` property will clean up master and worker jobs, but won't delete config maps or load tests. In case someone is looking for removal of load tests, config maps and jobs, [TwiN/k8s-ttl-controller](https://github.com/TwiN/k8s-ttl-controller) could be a good alternative.

Please let me know your thoughts on this PR.