### PR TITLE
feat(#89): add support for pulling the Locust image from private registries

### DIFF
--- a/docs/advanced_topics.md
+++ b/docs/advanced_topics.md
@@ -132,5 +132,35 @@ closely [Kubernetes native definition](https://kubernetes.io/docs/concepts/sched
     ```
 
 
+## Usage of a private image registry
 
+Images from a private image registry can be used through various methods as described in the [kubernetes documentation](https://kubernetes.io/docs/concepts/containers/images/#using-a-private-registry), one of those methods depends on setting `imagePullSecrets` for pods. This is supported in the operator by simply setting the `imagePullSecrets` option in the deployed custom resource. For example:
 
+```yaml title="locusttest-pull-secret-cr.yaml"
+apiVersion: locust.io/v1
+...
+spec:
+  image: ghcr.io/mycompany/locust:latest #(1)!
+  imagePullSecrets: #(2)!
+    - gcr-secret
+  ...
+```
+
+1. Specify which Locust image to use for both master and worker containers.
+2. [Optional] Specify an existing pull secret to use for master and worker pods.
+
+### Image pull policy
+
+Kubernetes uses the image tag and pull policy to control when kubelet attempts to download (pull) a container image. The image pull policy can be defined through the `imagePullPolicy` option, as explained in the [kubernetes documentation](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy). When using the operator, the `imagePullPolicy` option can be directly configured in the custom resource. For example:
+
+```yaml title="locusttest-pull-policy-cr.yaml"
+apiVersion: locust.io/v1
+...
+spec:
+  image: ghcr.io/mycompany/locust:latest #(1)!
+  imagePullPolicy: Always #(2)!
+  ...
+```
+
+1. Specify which Locust image to use for both master and worker containers.
+2. [Optional] Specify the pull policy to use for containers defined within master and worker containers. Supported options include `Always`, `IfNotPresent` and `Never`.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -67,7 +67,11 @@ spec:
 7. The amount of _worker_ nodes to spawn in the cluster.
 8. [Optional] Name of _configMap_ to mount into the pod
 
-Note that other options are available. In particular, you can add labels and annotations as well. For example:
+#### Other options
+
+##### Labels and annotations
+
+You can add labels and annotations to generated Pods. For example:
 
 ```yaml title="locusttest-cr.yaml"
 apiVersion: locust.io/v1

--- a/docs/helm_deploy.md
+++ b/docs/helm_deploy.md
@@ -30,7 +30,7 @@ In order to deploy using helm, follow the below steps:
 
 [//]: # (Resources urls)
 
-[crd-locusttest.yaml]: https://github.com/AbdelrhmanHamouda/locust-k8s-operator/blob/master/charts/locust-k8s-operator/templates/crd-locusttest.yaml
+[crd-locusttest.yaml]: https://github.com/AbdelrhmanHamouda/locust-k8s-operator/blob/master/kube/crd/locust-test-crd.yaml
 
 [serviceaccount-and-roles.yaml]: https://github.com/AbdelrhmanHamouda/locust-k8s-operator/blob/master/charts/locust-k8s-operator/templates/serviceaccount-and-roles.yaml
 

--- a/kube/crd/locust-test-crd.yaml
+++ b/kube/crd/locust-test-crd.yaml
@@ -109,6 +109,18 @@ spec:
                 image: # Child field 'image'
                   description: Locust image
                   type: string
+                imagePullPolicy:
+                  description: Image pull policy
+                  type: string
+                  enum:
+                    - "Always"
+                    - "IfNotPresent"
+                    - "Never"
+                imagePullSecrets:
+                  description: Secrets for pulling images from private registries
+                  type: array
+                  items:
+                    type: string
                 configMap: # Child field 'configMap'
                   description: Configuration map name containing the test
                   type: string

--- a/kube/sample-cr/locust-test-cr.yaml
+++ b/kube/sample-cr/locust-test-cr.yaml
@@ -4,6 +4,10 @@ metadata:
   name: demo.test
 spec:
   image: locustio/locust:latest
+  # [Optional-Section] Image pull policy and secrets
+  imagePullPolicy: Always
+  imagePullSecrets:
+    - "my-private-registry-secret"
 
   # [Optional-Section] Labels
   labels:

--- a/src/main/java/com/locust/operator/controller/dto/LoadGenerationNode.java
+++ b/src/main/java/com/locust/operator/controller/dto/LoadGenerationNode.java
@@ -25,6 +25,8 @@ public class LoadGenerationNode {
     private List<String> command;
     private OperationalMode operationalMode;
     private String image;
+    private String imagePullPolicy;
+    private List<String> imagePullSecrets;
     private Integer replicas;
     private List<Integer> ports;
     private String configMap;

--- a/src/main/java/com/locust/operator/controller/utils/LoadGenHelpers.java
+++ b/src/main/java/com/locust/operator/controller/utils/LoadGenHelpers.java
@@ -65,6 +65,8 @@ public class LoadGenHelpers {
             constructNodeCommand(resource, mode),
             mode,
             getNodeImage(resource),
+            getNodeImagePullPolicy(resource),
+            getNodeImagePullSecrets(resource),
             getReplicaCount(resource, mode),
             getNodePorts(resource, mode),
             getConfigMap(resource));
@@ -87,6 +89,14 @@ public class LoadGenHelpers {
 
         return resource.getSpec().getImage();
 
+    }
+
+    private String getNodeImagePullPolicy(LocustTest resource) {
+        return resource.getSpec().getImagePullPolicy();
+    }
+
+    private List<String> getNodeImagePullSecrets(LocustTest resource) {
+        return resource.getSpec().getImagePullSecrets();
     }
 
     public LocustTestAffinity getNodeAffinity(LocustTest resource) {

--- a/src/main/java/com/locust/operator/customresource/LocustTestSpec.java
+++ b/src/main/java/com/locust/operator/customresource/LocustTestSpec.java
@@ -36,5 +36,7 @@ public class LocustTestSpec implements KubernetesResource {
     private Integer workerReplicas;
     private String configMap;
     private String image;
+    private String imagePullPolicy;
+    private List<String> imagePullSecrets;
 
 }

--- a/src/test/java/com/locust/operator/controller/TestFixtures.java
+++ b/src/test/java/com/locust/operator/controller/TestFixtures.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -32,11 +33,13 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 @NoArgsConstructor(access = PRIVATE)
 public class TestFixtures {
 
-    public static final String CRD_FILE_PATH = "charts/locust-k8s-operator/templates/crd-locusttest.yaml";
+    public static final String CRD_FILE_PATH = "charts/locust-k8s-operator/crds/locust-test-crd.yaml";
     public static final String DEFAULT_API_VERSION = GROUP + "/" + VERSION;
     public static final String KIND = "LocustTest";
     public static final String DEFAULT_SEED_COMMAND = "--locustfile src/demo.py";
     public static final String DEFAULT_TEST_IMAGE = "xlocust:latest";
+    public static final String DEFAULT_IMAGE_PULL_POLICY = "IfNotPresent";
+    public static final List<String> DEFAULT_IMAGE_PULL_SECRETS = Collections.emptyList();
     public static final String DEFAULT_TEST_CONFIGMAP = "demo-test-configmap";
     public static final String DEFAULT_NAMESPACE = "default";
     public static final int REPLICAS = 50;
@@ -120,6 +123,8 @@ public class TestFixtures {
         spec.setWorkerCommandSeed(DEFAULT_SEED_COMMAND);
         spec.setConfigMap(DEFAULT_TEST_CONFIGMAP);
         spec.setImage(DEFAULT_TEST_IMAGE);
+        spec.setImagePullPolicy(DEFAULT_IMAGE_PULL_POLICY);
+        spec.setImagePullSecrets(DEFAULT_IMAGE_PULL_SECRETS);
         spec.setWorkerReplicas(replicas);
 
         var labels = new HashMap<String, Map<String, String>>();

--- a/src/test/java/com/locust/operator/controller/utils/TestFixtures.java
+++ b/src/test/java/com/locust/operator/controller/utils/TestFixtures.java
@@ -8,6 +8,8 @@ import com.locust.operator.customresource.internaldto.LocustTestAffinity;
 import com.locust.operator.customresource.internaldto.LocustTestNodeAffinity;
 import com.locust.operator.customresource.internaldto.LocustTestToleration;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.api.model.batch.v1.JobList;
 import lombok.NoArgsConstructor;
 import lombok.SneakyThrows;
@@ -132,11 +134,46 @@ public class TestFixtures {
 
     }
 
+    public static LoadGenerationNode prepareNodeConfigWithPullPolicyAndSecrets(
+        String nodeName, OperationalMode mode, String pullPolicy, List<String> pullSecrets) {
+
+        val nodeConfig = prepareNodeConfig(nodeName, mode);
+        nodeConfig.setImagePullPolicy(pullPolicy);
+        nodeConfig.setImagePullSecrets(pullSecrets);
+
+        return nodeConfig;
+
+    }
+
     public static <T extends KubernetesResourceList<?>> void assertK8sResourceCreation(String nodeName, T resourceList) {
 
         assertSoftly(softly -> {
             softly.assertThat(resourceList.getItems().size()).isEqualTo(EXPECTED_RESOURCE_COUNT);
             softly.assertThat(resourceList.getItems().get(0).getMetadata().getName()).isEqualTo(nodeName);
+        });
+
+    }
+
+    public static void assertImagePullData(LoadGenerationNode nodeConfig, PodList podList) {
+
+        podList.getItems().forEach(pod -> {
+            final List<String> references = pod.getSpec()
+                .getImagePullSecrets()
+                .stream()
+                .map(LocalObjectReference::getName)
+                .toList();
+
+            assertSoftly(softly -> {
+                softly.assertThat(references).isEqualTo(nodeConfig.getImagePullSecrets());
+            });
+
+            pod.getSpec()
+                .getContainers()
+                .forEach(container -> {
+                    assertSoftly(softly -> {
+                        softly.assertThat(container.getImagePullPolicy()).isEqualTo(nodeConfig.getImagePullPolicy());
+                    });
+                });
         });
 
     }


### PR DESCRIPTION
This pull request implements the feature proposed in https://github.com/AbdelrhmanHamouda/locust-k8s-operator/issues/89

I've added some documentation in the getting started page.

Please let me know your thoughts on this PR.

---

Note that I could've used Helm's convention to specify images (i.e., an `image` object with properties `repository`, `tag` and `pullPolicy`, plus an additional property `imagePullSecrets`) but decided against this because the operator already uses the key `image`. Doing so would've introduced a breaking change.