### PR TITLE
Set CPU and Memory resources for the metrics exporter container

### DIFF
--- a/src/main/java/com/locust/operator/controller/utils/resource/manage/ResourceCreationHelpers.java
+++ b/src/main/java/com/locust/operator/controller/utils/resource/manage/ResourceCreationHelpers.java
@@ -391,6 +391,9 @@ public class ResourceCreationHelpers {
             // Name
             .withName(EXPORTER_CONTAINER_NAME)
 
+            // Resource config
+            .withResources(loadGenHelpers.getResourceRequirements())
+
             // Image
             .withImage(EXPORTER_IMAGE)
             .withImagePullPolicy(pullPolicy)


### PR DESCRIPTION
The `locust-metrics-exporter` container does not have any CPU and Memory resources set. Set the same resources as the load gen container.