### PR TITLE
feat: implement pull secrets in helm chart 

### DIFF
--- a/charts/locust-k8s-operator/templates/deployment.yaml
+++ b/charts/locust-k8s-operator/templates/deployment.yaml
@@ -19,6 +19,12 @@ spec:
         {{- include "locust-k8s-operator.selectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "locust-k8s-operator.serviceAccountName" . }}
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/locust-k8s-operator/templates/serviceaccount-and-roles.yaml
+++ b/charts/locust-k8s-operator/templates/serviceaccount-and-roles.yaml
@@ -6,6 +6,12 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "locust-k8s-operator.labels" . | nindent 4 }}
+{{- if .Values.image.pullSecrets }}
+imagePullSecrets:
+{{- range .Values.image.pullSecrets}}
+  - name: {{ . }}
+{{- end }}
+{{- end }}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/locust-k8s-operator/values.yaml
+++ b/charts/locust-k8s-operator/values.yaml
@@ -9,6 +9,8 @@ replicaCount: 1
 image:
   repository: lotest/locust-k8s-operator
   pullPolicy: IfNotPresent
+  # List of names of secrets within the namespace to use imagePullSecrets. Applies to deployments and serviceAccounts
+  pullSecrets: []
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 


### PR DESCRIPTION
Supports the use of imagePullSecrets in `deployment` and `serviceAccount` objects. Useful for things like authenticating to DockerHub in systems that would otherwise hit pull limits. 

This would close #191 

Please note: I bypassed the pre-commit hooks as I did not change any of the Java code and am not currently set up with the required local Gradle toolchain. Apologies in advance.