### PR TITLE
Grant job patch permission

### DIFF
--- a/charts/locust-k8s-operator/Chart.yaml
+++ b/charts/locust-k8s-operator/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.0
+version: 0.9.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.9.0"
+appVersion: "0.9.1"

--- a/charts/locust-k8s-operator/templates/serviceaccount-and-roles.yaml
+++ b/charts/locust-k8s-operator/templates/serviceaccount-and-roles.yaml
@@ -45,6 +45,7 @@ rules:
       - create
       - update
       - delete
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
Hi!

Here's a fix for an issue we found after upgrading from 0.8.0 to 0.9.0 we have an error stating that the operator cannot patch a k8s job:
`2024-07-04 15:09:31,955 ERROR [ReconcilerExecutor-locusttestreconciler-480] com.locust.operator.controller.utils.resource.manage.ResourceCreationManager: Exception occurred during Job creation: Failure executing: PATCH at: https://10.100.0.1:443/apis/batch/v1/namespaces/locust/jobs/locust-email-reports-test-worker?fieldManager=fabric8. Message: jobs.batch "locust-email-reports-test-worker" is forbidden: User "system:serviceaccount:locust:locust-operator-locust-k8s-operator" cannot patch resource "jobs" in API group "batch" in the namespace "locust". Received status: Status(apiVersion=v1, code=403, details=StatusDetails(causes=[], group=batch, kind=jobs, name=locust-email-reports-test-worker, retryAfterSeconds=null, uid=null, additionalProperties={}), kind=Status, message=jobs.batch "locust-email-reports-test-worker" is forbidden: User "system:serviceaccount:locust:locust-operator-locust-k8s-operator" cannot patch resource "jobs" in API group "batch" in the namespace "locust", metadata=ListMeta(_continue=null, remainingItemCount=null, resourceVersion=null, selfLink=null, additionalProperties={}), reason=Forbidden, status=Failure, additionalProperties={}).`
