### PR TITLE
fix(ci): remove excessive SHA tag from Docker image releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,7 +44,7 @@ jobs:
           ko build ./cmd \
             --platform=linux/amd64,linux/arm64 \
             --bare \
-            --tags=${{ github.ref_name }},latest,${{ github.sha }}
+            --tags=${{ github.ref_name }},latest
 
   helm-chart-release:
     name: 🌊 Publish Helm chart


### PR DESCRIPTION
## Summary
Remove the full commit SHA tag from the release workflow's Docker image tagging strategy to eliminate registry pollution while maintaining full traceability.

## Changes
- Remove `,${{ github.sha }}` from `ko build` tags parameter in `.github/workflows/release.yaml`
- Future releases will only create two tags: version tag (e.g., `v2.0.0`) and `latest`

## Rationale
The SHA tag was introduced in commit `c68b6311` (Jan 20, 2026) during the Go operator CI/CD rewrite. While SHA tags can provide traceability, they create unnecessary registry pollution because:

1. **Version tags already provide full traceability** - Git tags are immutable and point to specific commits
2. **Docker images have SHA256 digests** - For absolute immutability needs, use image digests
3. **Users prefer semantic versions** - For rollbacks and deployments, version tags are more practical
4. **SHA tags clutter DockerHub** - 40-character tags accumulate without adding practical value

## Impact
- **Risk Level:** LOW
- Single-line removal (not modification)
- No downstream dependencies on SHA tags
- Easy rollback if needed
- Only affects future releases (existing images unchanged)
- Multi-platform build functionality unaffected

## Verification Plan
After merge, verify with next release:
- [ ] Build completes successfully
- [ ] Multi-platform images created (linux/amd64, linux/arm64)
- [ ] Only version + `latest` tags appear on DockerHub
- [ ] No SHA-based tag created
- [ ] Image pull works: `docker pull lotest/locust-k8s-operator:<version-tag>`

## Optional Follow-up
Consider cleaning up existing SHA-based tags from DockerHub manually or via API to reduce clutter.