### PR TITLE
fix(docs): correct Codacy badge URLs for code quality and coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,12 +124,12 @@ Open source licensed under Apache-2.0 license (see LICENSE file for details).
 [pipeline-status-url]: https://github.com/AbdelrhmanHamouda/locust-k8s-operator/actions/workflows/ci.yaml
 
 [//]: # (Code coverage badge)
-[code-coverage]: https://app.codacy.com/project/badge/Grade/70b76e69dbde4a9ebfd36ad5ccf6de78
-[code-coverage-url]: https://app.codacy.com/gh/AbdelrhmanHamouda/locust-k8s-operator/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade
+[code-coverage]: https://app.codacy.com/project/badge/Coverage/70b76e69dbde4a9ebfd36ad5ccf6de78?branch=master
+[code-coverage-url]: https://app.codacy.com/gh/AbdelrhmanHamouda/locust-k8s-operator/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_coverage
 
 [//]: # (Code quality badge)
-[code-quality]: https://app.codacy.com/project/badge/Coverage/70b76e69dbde4a9ebfd36ad5ccf6de78
-[code-quality-url]: https://app.codacy.com/gh/AbdelrhmanHamouda/locust-k8s-operator/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_coverage
+[code-quality]: https://app.codacy.com/project/badge/Grade/70b76e69dbde4a9ebfd36ad5ccf6de78?branch=master
+[code-quality-url]: https://app.codacy.com/gh/AbdelrhmanHamouda/locust-k8s-operator/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade
 [//]: # (Documentation badge)
 [docs]: https://img.shields.io/badge/Documentation-gh--pages-green
 [docs-url]:https://abdelrhmanhamouda.github.io/locust-k8s-operator/

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,10 +58,10 @@ hide:
       <img src="https://github.com/AbdelrhmanHamouda/locust-k8s-operator/actions/workflows/ci.yaml/badge.svg?branch=master" alt="CI Pipeline" class="badge">
     </a>
     <a href="https://app.codacy.com/gh/AbdelrhmanHamouda/locust-k8s-operator/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade" target="_blank">
-      <img src="https://app.codacy.com/project/badge/Grade/70b76e69dbde4a9ebfd36ad5ccf6de78" alt="Code Quality" class="badge">
+      <img src="https://app.codacy.com/project/badge/Grade/70b76e69dbde4a9ebfd36ad5ccf6de78?branch=master" alt="Code Quality" class="badge">
     </a>
     <a href="https://app.codacy.com/gh/AbdelrhmanHamouda/locust-k8s-operator/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_coverage" target="_blank">
-      <img src="https://app.codacy.com/project/badge/Coverage/70b76e69dbde4a9ebfd36ad5ccf6de78" alt="Code Coverage" class="badge">
+      <img src="https://app.codacy.com/project/badge/Coverage/70b76e69dbde4a9ebfd36ad5ccf6de78?branch=master" alt="Code Coverage" class="badge">
     </a>
     <a href="https://hub.docker.com/r/lotest/locust-k8s-operator" target="_blank">
       <img src="https://img.shields.io/docker/pulls/lotest/locust-k8s-operator?style=flat&logo=docker&logoColor=green&label=Image%20Pulls&color=green" alt="Docker Pulls" class="badge">


### PR DESCRIPTION
Swap mismatched badge URLs so code quality badge shows Grade metric and code coverage badge shows Coverage metric. Add branch=master parameter to both badges for accurate master branch reporting.