### PR TITLE
ci: consolidate SBOMs onto chart release, drop bare-semver release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,8 +15,10 @@ jobs:
     name: 🐳 Publish image
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # SBOMs are generated here but uploaded to the chart release in the
+    # helm-chart-release job (avoids creating a separate bare-semver release).
     permissions:
-      contents: write # Required for uploading release assets
+      contents: read
     env:
       DOCKER_IMAGE: lotest/locust-k8s-operator
     steps:
@@ -60,15 +62,15 @@ jobs:
           format: cyclonedx
           output: sbom-cyclonedx.json
 
-      - name: 📦 Upload SBOMs to release
-        uses: softprops/action-gh-release@v2
+      - name: 📤 Stash SBOMs for chart release job
+        uses: actions/upload-artifact@v7
         with:
-          files: |
+          name: sboms
+          path: |
             sbom-spdx.json
             sbom-cyclonedx.json
-          fail_on_unmatched_files: false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          if-no-files-found: error
+          retention-days: 7
 
   helm-chart-release:
     name: 🌊 Publish Helm chart
@@ -111,6 +113,22 @@ jobs:
           skip_packaging: true
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: 📥 Fetch SBOMs from publish-image job
+        uses: actions/download-artifact@v7
+        with:
+          name: sboms
+
+      - name: 📦 Attach SBOMs to chart release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: locust-k8s-operator-${{ github.ref_name }}
+          files: |
+            sbom-spdx.json
+            sbom-cyclonedx.json
+          fail_on_unmatched_files: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   docs-release:
     name: 📚 Publish documentation


### PR DESCRIPTION
## Summary

The SBOM upload step in `release.yaml` used `softprops/action-gh-release@v2` against the bare semver tag (`github.ref_name`, e.g. `2.2.0`), which side-effected a duplicate GitHub Release for every tag in addition to the chart-releaser-managed `locust-k8s-operator-X.Y.Z` release. Historically (pre-v2.0 Go rewrite) only the chart-prefixed releases existed; the bare-semver releases first appeared with the SBOM step.

This PR keeps SBOMs published, but routes them onto the chart release instead, eliminating the duplicate.

### How it works

- `publish-image` job: SBOMs are now stashed as a workflow artifact (`actions/upload-artifact@v7`) instead of being uploaded directly to a release.
- `helm-chart-release` job: after `chart-releaser-action` creates `locust-k8s-operator-X.Y.Z`, the SBOMs are pulled from the artifact (`actions/download-artifact@v7`) and attached to that release via `softprops/action-gh-release@v2` with an explicit `tag_name`.
- `publish-image` no longer needs `contents: write` (it never touches the GitHub repo now); dropped to `contents: read`.

### Impact

- **CI tests / lint / security scans**: untouched — different workflow file
- **Docker image build/push**: unchanged
- **Helm chart `.tgz` publish + `gh-pages/index.yaml`**: unchanged
- **Docs deploy**: unchanged
- **SBOMs**: still published, URL changes from `releases/download/X.Y.Z/sbom-*.json` → `releases/download/locust-k8s-operator-X.Y.Z/sbom-*.json` going forward
- **Pre-existing bare-semver releases (`2.1.1`, `2.2.0`, `2.2.1`)**: untouched. Cleanup is a separate manual step if desired.

### Why this matters

- One release per tag is the historical convention and the cleaner UX.
- Fewer redundant GitHub Releases = less clutter in `gh release list` and the releases UI.
- `publish-image` job now follows least-privilege (read-only `contents`).

## Test plan

- [ ] PR CI passes (workflow YAML parses, lint OK)
- [ ] Next tag push triggers `release.yaml` and:
  - [ ] `publish-image` succeeds and uploads SBOMs as a workflow artifact
  - [ ] `helm-chart-release` succeeds, with SBOMs attached to the chart release
  - [ ] No new bare-semver release is created
- [ ] SBOMs downloadable from the chart release URL