### PR TITLE
fix(security): bump Go from 1.26.2 to 1.26.3 to resolve stdlib CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/AbdelrhmanHamouda/locust-k8s-operator
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
## Summary

Bumps Go version from `1.26.2` to `1.26.3` to fix 8 stdlib CVEs reported in #294.

## CVEs Fixed

All are in Go stdlib, installed version `v1.26.2`, fixed in `v1.26.3`:

| CVE | Severity |
|-----|----------|
| CVE-2026-33811 | HIGH |
| CVE-2026-33814 | HIGH |
| CVE-2026-39820 | HIGH |
| CVE-2026-39836 | HIGH |
| CVE-2026-42499 | HIGH |
| CVE-2026-39823 | MEDIUM |
| CVE-2026-39825 | MEDIUM |
| CVE-2026-39826 | MEDIUM |

## Verification

Built and scanned the image locally with Trivy — **0 vulnerabilities** detected.

Closes #294