### PR TITLE
fix: look up resources by sanitized names to stop recovery loop

### DIFF
--- a/internal/controller/locusttest_controller.go
+++ b/internal/controller/locusttest_controller.go
@@ -277,6 +277,15 @@ func (r *LocustTestReconciler) handleExternalResourceDeletion(
 	// Try to fetch the resource
 	if err := r.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: lt.Namespace}, obj); err != nil {
 		if apierrors.IsNotFound(err) {
+			// Don't trigger recovery for terminal states - resources may have been cleaned up
+			// legitimately (e.g. Job TTL after the test finished)
+			if shouldSkipStatusUpdate(lt) {
+				log.V(1).Info(fmt.Sprintf("%s not found but test is in terminal state, skipping recovery", resourceKind),
+					resourceKind, resourceName,
+					"phase", lt.Status.Phase)
+				return false, 0, nil
+			}
+
 			// Resource was externally deleted — transition to Pending for recovery
 			log.Info(fmt.Sprintf("%s externally deleted, transitioning to Pending for recovery", resourceKind),
 				resourceKind, resourceName)
@@ -325,8 +334,10 @@ func (r *LocustTestReconciler) checkResourcesExist(
 	ctx context.Context,
 	lt *locustv2.LocustTest,
 ) (*batchv1.Job, *batchv1.Job, bool, time.Duration, error) {
-	// Check for externally deleted Service
-	masterServiceName := lt.Name + "-master"
+	// Check for externally deleted Service.
+	// Look up by the sanitized resource name (dots replaced with dashes) that the
+	// builders actually use — a raw lt.Name lookup never matches dotted CR names.
+	masterServiceName := resources.NodeName(lt.Name, resources.Master)
 	masterService := &corev1.Service{}
 	if shouldRequeue, requeueAfter, err := r.handleExternalResourceDeletion(
 		ctx, lt, masterServiceName, "Master Service", masterService,
@@ -338,7 +349,7 @@ func (r *LocustTestReconciler) checkResourcesExist(
 
 	// Check for externally deleted master Job
 	masterJob := &batchv1.Job{}
-	masterJobName := lt.Name + "-master"
+	masterJobName := resources.NodeName(lt.Name, resources.Master)
 	if shouldRequeue, requeueAfter, err := r.handleExternalResourceDeletion(
 		ctx, lt, masterJobName, "Master Job", masterJob,
 	); err != nil {
@@ -349,7 +360,7 @@ func (r *LocustTestReconciler) checkResourcesExist(
 
 	// Check for externally deleted worker Job
 	workerJob := &batchv1.Job{}
-	workerJobName := lt.Name + "-worker"
+	workerJobName := resources.NodeName(lt.Name, resources.Worker)
 	if shouldRequeue, requeueAfter, err := r.handleExternalResourceDeletion(
 		ctx, lt, workerJobName, "Worker Job", workerJob,
 	); err != nil {

--- a/internal/controller/locusttest_controller_unit_test.go
+++ b/internal/controller/locusttest_controller_unit_test.go
@@ -1113,6 +1113,155 @@ func TestReconcile_ExternalDeletion_WorkerJob(t *testing.T) {
 	assert.Equal(t, locustv2.PhaseRunning, lt.Status.Phase, "Phase should be Running after recreation")
 }
 
+// Regression test for the recovery loop with dotted CR names: resources are
+// created via resources.NodeName (dots replaced with dashes), so the existence
+// checks must look them up by the same sanitized name. Before the fix,
+// checkResourcesExist used the raw CR name, saw NotFound on every reconcile,
+// and reset a healthy Running test to Pending forever.
+func TestReconcile_DottedName_NoSpuriousRecovery(t *testing.T) {
+	lt := newTestLocustTestCR("my-test.v2", "default")
+	reconciler, recorder := newTestReconciler(lt)
+	ctx := context.Background()
+
+	// First reconcile - creates resources and transitions to Running
+	_, err := reconciler.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "my-test.v2",
+			Namespace: "default",
+		},
+	})
+	require.NoError(t, err)
+
+	// Resources are created under the sanitized name
+	masterService := &corev1.Service{}
+	err = reconciler.Get(ctx, types.NamespacedName{
+		Name:      "my-test-v2-master",
+		Namespace: "default",
+	}, masterService)
+	require.NoError(t, err, "master Service should exist under the sanitized name")
+
+	// Drain creation events from first reconcile
+	for i := 0; i < 3; i++ {
+		select {
+		case <-recorder.Events:
+		default:
+		}
+	}
+
+	// Mark the Jobs as actively running so status derivation keeps Running
+	for _, jobName := range []string{"my-test-v2-master", "my-test-v2-worker"} {
+		job := &batchv1.Job{}
+		err = reconciler.Get(ctx, types.NamespacedName{
+			Name:      jobName,
+			Namespace: "default",
+		}, job)
+		require.NoError(t, err, "Job should exist under the sanitized name")
+		job.Status.Active = 1
+		require.NoError(t, reconciler.Status().Update(ctx, job))
+		require.NoError(t, reconciler.Get(ctx, types.NamespacedName{Name: jobName, Namespace: "default"}, job))
+		require.Equal(t, int32(1), job.Status.Active, "job Active status must persist in fake client")
+	}
+
+	// Second reconcile - resources exist, so no recovery must be triggered
+	result, err := reconciler.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "my-test.v2",
+			Namespace: "default",
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, time.Duration(0), result.RequeueAfter, "healthy test should not trigger recovery requeue")
+
+	select {
+	case event := <-recorder.Events:
+		assert.NotContains(t, event, "ResourceDeleted",
+			"healthy dotted-name test must not be treated as externally deleted")
+	default:
+	}
+
+	// Phase must remain Running, not be reset to Pending
+	err = reconciler.Get(ctx, types.NamespacedName{
+		Name:      "my-test.v2",
+		Namespace: "default",
+	}, lt)
+	require.NoError(t, err)
+	assert.Equal(t, locustv2.PhaseRunning, lt.Status.Phase,
+		"Phase must stay Running; before the fix it thrashed to Pending on every reconcile")
+}
+
+// Terminal tests must not be resurrected when their resources are cleaned up
+// legitimately (e.g. Job TTL after completion): missing resources in a
+// terminal phase skip recovery instead of resetting the test to Pending.
+func TestReconcile_TerminalPhase_SkipsRecoveryAfterCleanup(t *testing.T) {
+	lt := newTestLocustTestCR("my-test", "default")
+	reconciler, recorder := newTestReconciler(lt)
+	ctx := context.Background()
+
+	// First reconcile - creates resources and transitions to Running
+	_, err := reconciler.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "my-test",
+			Namespace: "default",
+		},
+	})
+	require.NoError(t, err)
+
+	// Drain creation events from first reconcile
+	for i := 0; i < 3; i++ {
+		select {
+		case <-recorder.Events:
+		default:
+		}
+	}
+
+	// Simulate a completed test
+	err = reconciler.Get(ctx, types.NamespacedName{
+		Name:      "my-test",
+		Namespace: "default",
+	}, lt)
+	require.NoError(t, err)
+	lt.Status.Phase = locustv2.PhaseSucceeded
+	require.NoError(t, reconciler.Status().Update(ctx, lt))
+
+	// Simulate TTL cleanup: all owned resources are gone
+	masterService := &corev1.Service{}
+	require.NoError(t, reconciler.Get(ctx, types.NamespacedName{Name: "my-test-master", Namespace: "default"}, masterService))
+	require.NoError(t, reconciler.Delete(ctx, masterService))
+	for _, jobName := range []string{"my-test-master", "my-test-worker"} {
+		job := &batchv1.Job{}
+		require.NoError(t, reconciler.Get(ctx, types.NamespacedName{Name: jobName, Namespace: "default"}, job))
+		require.NoError(t, reconciler.Delete(ctx, job))
+	}
+
+	// Reconcile - must not trigger recovery for a finished test
+	result, err := reconciler.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "my-test",
+			Namespace: "default",
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result, "terminal test should not requeue")
+
+	select {
+	case event := <-recorder.Events:
+		assert.NotContains(t, event, "ResourceDeleted",
+			"terminal-phase cleanup must not be treated as external deletion")
+	default:
+	}
+
+	// Phase must remain Succeeded and resources must not be recreated
+	err = reconciler.Get(ctx, types.NamespacedName{
+		Name:      "my-test",
+		Namespace: "default",
+	}, lt)
+	require.NoError(t, err)
+	assert.Equal(t, locustv2.PhaseSucceeded, lt.Status.Phase, "finished test must not be reset to Pending")
+
+	err = reconciler.Get(ctx, types.NamespacedName{Name: "my-test-master", Namespace: "default"}, &corev1.Service{})
+	assert.True(t, apierrors.IsNotFound(err), "master Service must not be recreated for a finished test")
+}
+
 // conflictOnUpdateClient wraps a client.Client and returns 409 Conflict errors
 // on the first N Status().Update() calls, then delegates to the real client.
 type conflictOnUpdateClient struct {


### PR DESCRIPTION
## Problem

LocustTests could get stuck thrashing between `Pending`/`Running` forever, with completed Jobs but a CR that never reached `Succeeded` (18 recovery iterations in ~5s in the repro below). Originally reported as #50.

## Root cause

Resources are *created* via `resources.NodeName()`, which sanitizes dots in the CR name to dashes, but `checkResourcesExist` looked them up by raw `lt.Name + "-master"/"-worker"`. For a dotted CR name like `test-buggy.2`, the real Service/Jobs are `test-buggy-2-master/...`, so every lookup returned NotFound. The operator treated that as an external deletion and reset the test to `Pending`, recreating resources on every reconcile — the operator never actually deletes resources while the CR exists, so the "deletion" was pure name mismatch.

## Fix

- `checkResourcesExist` now builds lookup names with `resources.NodeName()`, matching what the builders create.
- External-deletion recovery is skipped when the test is already in a terminal phase (`Succeeded`/`Failed`), so legitimate cleanup — e.g. `JOB_TTL_SECONDS_AFTER_FINISHED` GC — doesn't resurrect a finished test.

## Tests

- `TestReconcile_DottedName_NoSpuriousRecovery` — dotted CR name stays `Running` across reconciles, no `ResourceDeleted` event, no requeue (fails before the fix).
- `TestReconcile_TerminalPhase_SkipsRecoveryAfterCleanup` — a `Succeeded` test whose resources were cleaned up is not reset to `Pending` and resources are not recreated.
- Existing external-deletion tests pass unchanged, so genuine self-healing is intact.

## Bug Reproduction

Note the dotted CR name — that's exactly why it triggered.

### LocustTest CR
```yaml
apiVersion: locust.io/v2
kind: LocustTest
metadata:
  name: test-buggy.2
spec:
  image: locustio/locust:2.32.4
  master:
    command: "--locustfile /lotest/src/minimal-test.py --host http://httpbin.org --users 1 --spawn-rate 1 --run-time 60s --headless"
  worker:
    command: "--locustfile /lotest/src/minimal-test.py"
    replicas: 1
  testFiles:
    configMapRef: minimal-test
```

### Result (before fix)

```
$ kubectl get locusttest
NAME          PHASE     WORKERS   CONNECTED   AGE
test-buggy.2  Pending   1                     85s

$ kubectl get jobs
NAME                   STATUS     COMPLETIONS   DURATION
test-buggy-2-master    Complete   1/1           74s
test-buggy-2-worker    Complete   1/1           71s
```

Both Jobs completed but the LocustTest is stuck at `Pending`.

### Operator Logs (recovery loop)
```
Master Service externally deleted, transitioning to Pending for recovery
Attempting to update status to Pending after external deletion  currentPhase=Running
Successfully updated status to Pending, will recreate Master Service
All resources created successfully
Master Service externally deleted, transitioning to Pending for recovery
...
```

18 recovery iterations in ~5 seconds, test never reaches Succeeded.

## Related

- Issue #50 (closed, claimed fixed in v2 but bug persists)
