### PR TITLE
fix: use native sidecar for metrics exporter (k8s 1.29+)

### DIFF
--- a/charts/locust-k8s-operator/Chart.yaml
+++ b/charts/locust-k8s-operator/Chart.yaml
@@ -35,7 +35,7 @@ version: 2.2.3
 # It is recommended to use it with quotes.
 appVersion: "2.2.3"
 
-kubeVersion: ">= 1.25.0-0"
+kubeVersion: ">= 1.29.0-0"
 home: https://github.com/AbdelrhmanHamouda/locust-k8s-operator
 sources:
   - https://github.com/AbdelrhmanHamouda/locust-k8s-operator

--- a/charts/locust-k8s-operator/Chart.yaml
+++ b/charts/locust-k8s-operator/Chart.yaml
@@ -27,13 +27,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.3
+version: 2.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.2.3"
+appVersion: "2.3.0"
 
 kubeVersion: ">= 1.29.0-0"
 home: https://github.com/AbdelrhmanHamouda/locust-k8s-operator
@@ -62,17 +62,7 @@ annotations:
     - name: GitHub Issues
       url: https://github.com/AbdelrhmanHamouda/locust-k8s-operator/issues
   artifacthub.io/changes: |
+    - kind: fixed
+      description: Metrics exporter now runs as a native sidecar so load-test Jobs complete instead of hanging indefinitely
     - kind: changed
-      description: Rewritten for Go operator with clean-slate design
-    - kind: changed
-      description: Updated health probes to /healthz and /readyz on port 8081
-    - kind: changed
-      description: Reduced default memory from 1Gi to 128Mi (Go binary)
-    - kind: added
-      description: Leader election support for HA deployments
-    - kind: added
-      description: Optional webhook configuration with cert-manager
-    - kind: added
-      description: Optional OTel Collector deployment
-    - kind: deprecated
-      description: Micronaut/JVM configuration removed (no longer applicable)
+      description: Minimum supported Kubernetes version raised to 1.29 (required for native sidecar containers)

--- a/charts/locust-k8s-operator/README.md
+++ b/charts/locust-k8s-operator/README.md
@@ -17,7 +17,7 @@ Production-ready Kubernetes operator for distributed Locust load testing with na
 
 ### Prerequisites
 
-- Kubernetes 1.25+
+- Kubernetes 1.29+
 - Helm 3.x
 
 ### Quick Start

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -181,7 +181,7 @@ The v2 operator was rewritten from Java to Go for several key reasons:
 
 #### Prerequisites
 
-- Kubernetes 1.25+
+- Kubernetes 1.29+
 - Helm 3.x
 - cert-manager v1.14+ (required for conversion webhook)
 

--- a/internal/controller/integration_test.go
+++ b/internal/controller/integration_test.go
@@ -123,7 +123,8 @@ var _ = Describe("LocustTest Controller Integration", func() {
 			// Verify master Job properties
 			Expect(*createdJob.Spec.Parallelism).To(Equal(int32(1)))
 			// Completions is not explicitly set in the builder (nil means 1 by default)
-			Expect(createdJob.Spec.Template.Spec.Containers).To(HaveLen(2)) // locust + metrics
+			Expect(createdJob.Spec.Template.Spec.Containers).To(HaveLen(1))     // locust
+			Expect(createdJob.Spec.Template.Spec.InitContainers).To(HaveLen(1)) // metrics exporter (native sidecar)
 		})
 
 		It("should create worker Job when LocustTest is created", func() {

--- a/internal/controller/locusttest_controller_unit_test.go
+++ b/internal/controller/locusttest_controller_unit_test.go
@@ -383,8 +383,9 @@ func TestReconcile_VerifyMasterJobConfiguration(t *testing.T) {
 	require.NotNil(t, job.Spec.Parallelism)
 	assert.Equal(t, int32(1), *job.Spec.Parallelism)
 
-	// Verify master has 2 containers (locust + metrics exporter)
-	assert.Len(t, job.Spec.Template.Spec.Containers, 2)
+	// Verify master has 1 main container (locust); metrics exporter is now a native sidecar initContainer.
+	assert.Len(t, job.Spec.Template.Spec.Containers, 1)
+	assert.Len(t, job.Spec.Template.Spec.InitContainers, 1)
 
 	// Verify RestartPolicy is Never
 	assert.Equal(t, corev1.RestartPolicyNever, job.Spec.Template.Spec.RestartPolicy)

--- a/internal/controller/pod_health.go
+++ b/internal/controller/pod_health.go
@@ -148,16 +148,26 @@ func analyzePodFailure(pod *corev1.Pod, lt *locustv2.LocustTest) *PodFailureInfo
 		}
 	}
 
+	// Identify native sidecars (initContainers with restartPolicy: Always, KEP-753).
+	// Kubelet SIGTERMs these when the main containers exit; that termination is expected
+	// and must not race the JobComplete signal to incorrectly mark the test Failed.
+	nativeSidecars := make(map[string]bool)
+	for _, c := range pod.Spec.InitContainers {
+		if c.RestartPolicy != nil && *c.RestartPolicy == corev1.ContainerRestartPolicyAlways {
+			nativeSidecars[c.Name] = true
+		}
+	}
+
 	// Check init containers
 	for _, initStatus := range pod.Status.InitContainerStatuses {
-		if failure := analyzeContainerStatus(pod.Name, initStatus, true, lt); failure != nil {
+		if failure := analyzeContainerStatus(pod.Name, initStatus, true, nativeSidecars[initStatus.Name], lt); failure != nil {
 			return failure
 		}
 	}
 
 	// Check main containers
 	for _, containerStatus := range pod.Status.ContainerStatuses {
-		if failure := analyzeContainerStatus(pod.Name, containerStatus, false, lt); failure != nil {
+		if failure := analyzeContainerStatus(pod.Name, containerStatus, false, false, lt); failure != nil {
 			return failure
 		}
 	}
@@ -167,7 +177,11 @@ func analyzePodFailure(pod *corev1.Pod, lt *locustv2.LocustTest) *PodFailureInfo
 }
 
 // analyzeContainerStatus checks a container status for failures.
-func analyzeContainerStatus(podName string, status corev1.ContainerStatus, isInitContainer bool, lt *locustv2.LocustTest) *PodFailureInfo {
+// isNativeSidecar=true means the container's RestartPolicy is Always (KEP-753 native sidecar).
+// Native sidecars have their Terminated state ignored because kubelet SIGTERMs them at
+// pod end-of-life; genuine failures still surface via the Waiting checks (CrashLoopBackOff,
+// ImagePullBackOff, CreateContainerConfigError), which run for all containers.
+func analyzeContainerStatus(podName string, status corev1.ContainerStatus, isInitContainer bool, isNativeSidecar bool, lt *locustv2.LocustTest) *PodFailureInfo {
 	// Check waiting state
 	if status.State.Waiting != nil {
 		waiting := status.State.Waiting
@@ -200,8 +214,11 @@ func analyzeContainerStatus(podName string, status corev1.ContainerStatus, isIni
 		}
 	}
 
-	// Check terminated state (for init containers or recently failed containers)
-	if status.State.Terminated != nil {
+	// Check terminated state (for init containers or recently failed containers).
+	// Skip for native sidecars: kubelet SIGTERMs them when main containers exit, so
+	// their non-zero terminated exit is expected and would otherwise race the
+	// JobComplete signal and flag a successful test as Failed.
+	if !isNativeSidecar && status.State.Terminated != nil {
 		terminated := status.State.Terminated
 		if terminated.ExitCode != 0 {
 			failureType := locustv2.ReasonPodInitError

--- a/internal/controller/pod_health_test.go
+++ b/internal/controller/pod_health_test.go
@@ -126,6 +126,49 @@ func TestAnalyzePodFailure(t *testing.T) {
 			expectedNil:    false,
 			expectedReason: locustv2.ReasonPodCrashLoop,
 		},
+		{
+			// Race-condition guard at the caller level: pod has the metrics-exporter
+			// as a native sidecar (initContainer with RestartPolicy: Always). After the
+			// main container exits, kubelet SIGTERMs the sidecar; the resulting non-zero
+			// exit must not flag the pod as failed.
+			name: "native sidecar terminated by SIGTERM does not fail pod",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "succeeded-pod"},
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name:          "locust-metrics-exporter",
+							RestartPolicy: func() *corev1.ContainerRestartPolicy { p := corev1.ContainerRestartPolicyAlways; return &p }(),
+						},
+					},
+				},
+				Status: corev1.PodStatus{
+					InitContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name: "locust-metrics-exporter",
+							State: corev1.ContainerState{
+								Terminated: &corev1.ContainerStateTerminated{
+									ExitCode: 2,
+									Reason:   "Error",
+								},
+							},
+						},
+					},
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name: "locust",
+							State: corev1.ContainerState{
+								Terminated: &corev1.ContainerStateTerminated{
+									ExitCode: 0,
+									Reason:   "Completed",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedNil: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -157,6 +200,7 @@ func TestAnalyzeContainerStatus(t *testing.T) {
 		name            string
 		status          corev1.ContainerStatus
 		isInitContainer bool
+		isNativeSidecar bool
 		expectedNil     bool
 		expectedReason  string
 	}{
@@ -267,11 +311,47 @@ func TestAnalyzeContainerStatus(t *testing.T) {
 			},
 			expectedNil: true,
 		},
+		{
+			// Race-condition guard: native sidecar (e.g. metrics exporter) was SIGTERM'd by
+			// kubelet at pod end-of-life. Without this exemption, the non-zero exit code
+			// would race the JobComplete signal and mark a successful test as Failed.
+			name: "native sidecar terminated with non-zero exit returns nil",
+			status: corev1.ContainerStatus{
+				Name: "locust-metrics-exporter",
+				State: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{
+						ExitCode: 2,
+						Reason:   "Error",
+					},
+				},
+			},
+			isInitContainer: true,
+			isNativeSidecar: true,
+			expectedNil:     true,
+		},
+		{
+			// Native sidecar exemption must NOT mask genuine startup failures —
+			// CrashLoopBackOff still surfaces because it lives in Waiting, not Terminated.
+			name: "native sidecar in CrashLoopBackOff still returns ReasonPodCrashLoop",
+			status: corev1.ContainerStatus{
+				Name: "locust-metrics-exporter",
+				State: corev1.ContainerState{
+					Waiting: &corev1.ContainerStateWaiting{
+						Reason:  "CrashLoopBackOff",
+						Message: "back-off 5m0s restarting failed container",
+					},
+				},
+			},
+			isInitContainer: true,
+			isNativeSidecar: true,
+			expectedNil:     false,
+			expectedReason:  locustv2.ReasonPodCrashLoop,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := analyzeContainerStatus("test-pod", tt.status, tt.isInitContainer, lt)
+			result := analyzeContainerStatus("test-pod", tt.status, tt.isInitContainer, tt.isNativeSidecar, lt)
 			if tt.expectedNil {
 				assert.Nil(t, result)
 			} else {

--- a/internal/resources/job.go
+++ b/internal/resources/job.go
@@ -75,9 +75,11 @@ func buildJob(lt *locustv2.LocustTest, cfg *config.OperatorConfig, mode Operatio
 		buildLocustContainer(lt, nodeName, command, ports, cfg, mode),
 	}
 
-	// Master gets the metrics exporter sidecar ONLY if OTel is disabled
+	// Build native sidecar containers (initContainers with restartPolicy: Always)
+	// Native sidecars (k8s 1.28+) auto-terminate when main containers complete
+	var initContainers []corev1.Container
 	if mode == Master && !IsOTelEnabled(lt) {
-		containers = append(containers, buildMetricsExporterContainer(cfg))
+		initContainers = append(initContainers, buildMetricsExporterSidecar(cfg))
 	}
 
 	backoffLimit := int32(BackoffLimit)
@@ -99,6 +101,7 @@ func buildJob(lt *locustv2.LocustTest, cfg *config.OperatorConfig, mode Operatio
 				Spec: corev1.PodSpec{
 					RestartPolicy:    corev1.RestartPolicyNever,
 					ImagePullSecrets: buildImagePullSecrets(lt),
+					InitContainers:   initContainers,
 					Containers:       containers,
 					Volumes:          buildVolumes(lt, nodeName, mode),
 					Affinity:         buildAffinity(lt, cfg),
@@ -140,12 +143,14 @@ func buildLocustContainer(lt *locustv2.LocustTest, name string, command []string
 	return container
 }
 
-// buildMetricsExporterContainer creates the Prometheus metrics exporter sidecar container.
-func buildMetricsExporterContainer(cfg *config.OperatorConfig) corev1.Container {
+// buildMetricsExporterSidecar creates a native sidecar (k8s 1.28+) for the metrics exporter.
+// Native sidecars are initContainers with restartPolicy: Always that auto-terminate when main containers complete.
+func buildMetricsExporterSidecar(cfg *config.OperatorConfig) corev1.Container {
 	return corev1.Container{
 		Name:            MetricsExporterContainerName,
 		Image:           cfg.MetricsExporterImage,
 		ImagePullPolicy: corev1.PullPolicy(cfg.MetricsExporterPullPolicy),
+		RestartPolicy:   ptr.To(corev1.ContainerRestartPolicyAlways),
 		Ports: []corev1.ContainerPort{
 			{ContainerPort: cfg.MetricsExporterPort},
 		},

--- a/internal/resources/job_test.go
+++ b/internal/resources/job_test.go
@@ -118,15 +118,12 @@ func TestBuildMasterJob_Containers(t *testing.T) {
 	job := BuildMasterJob(lt, cfg, logr.Discard())
 
 	containers := job.Spec.Template.Spec.Containers
-	assert.Len(t, containers, 2, "Master should have 2 containers (locust + metrics exporter)")
+	assert.Len(t, containers, 1, "Master should have 1 main container (locust); metrics exporter is a native sidecar")
+	assert.Equal(t, "my-test-master", containers[0].Name)
 
-	// Find container names
-	containerNames := make([]string, len(containers))
-	for i, c := range containers {
-		containerNames[i] = c.Name
-	}
-	assert.Contains(t, containerNames, "my-test-master")
-	assert.Contains(t, containerNames, MetricsExporterContainerName)
+	initContainers := job.Spec.Template.Spec.InitContainers
+	assert.Len(t, initContainers, 1, "Master should have the metrics exporter as a native sidecar initContainer")
+	assert.Equal(t, MetricsExporterContainerName, initContainers[0].Name)
 }
 
 func TestBuildMasterJob_WithTTL(t *testing.T) {
@@ -809,13 +806,11 @@ func TestBuildMasterJob_OTelDisabled_HasSidecar(t *testing.T) {
 	job := BuildMasterJob(lt, cfg, logr.Discard())
 
 	containers := job.Spec.Template.Spec.Containers
-	assert.Len(t, containers, 2, "Master should have 2 containers (locust + metrics exporter) when OTel disabled")
+	assert.Len(t, containers, 1, "Master should have 1 main container (locust); metrics exporter is a native sidecar")
 
-	containerNames := make([]string, len(containers))
-	for i, c := range containers {
-		containerNames[i] = c.Name
-	}
-	assert.Contains(t, containerNames, MetricsExporterContainerName)
+	initContainers := job.Spec.Template.Spec.InitContainers
+	assert.Len(t, initContainers, 1, "Metrics exporter should be a native sidecar (initContainer) when OTel disabled")
+	assert.Equal(t, MetricsExporterContainerName, initContainers[0].Name)
 }
 
 func TestBuildMasterJob_OTelEnabled_NoSidecar(t *testing.T) {
@@ -833,6 +828,7 @@ func TestBuildMasterJob_OTelEnabled_NoSidecar(t *testing.T) {
 	containers := job.Spec.Template.Spec.Containers
 	assert.Len(t, containers, 1, "Master should have 1 container only when OTel enabled")
 	assert.Equal(t, "my-test-master", containers[0].Name)
+	assert.Empty(t, job.Spec.Template.Spec.InitContainers, "No native-sidecar exporter should be added when OTel enabled")
 }
 
 func TestBuildMasterJob_NoObservability_HasSidecar(t *testing.T) {
@@ -843,7 +839,11 @@ func TestBuildMasterJob_NoObservability_HasSidecar(t *testing.T) {
 	job := BuildMasterJob(lt, cfg, logr.Discard())
 
 	containers := job.Spec.Template.Spec.Containers
-	assert.Len(t, containers, 2, "Master should have 2 containers when observability is nil")
+	assert.Len(t, containers, 1, "Master should have 1 main container (locust) when observability is nil")
+
+	initContainers := job.Spec.Template.Spec.InitContainers
+	assert.Len(t, initContainers, 1, "Metrics exporter should be a native sidecar (initContainer) when observability is nil")
+	assert.Equal(t, MetricsExporterContainerName, initContainers[0].Name)
 }
 
 func TestBuildWorkerJob_OTelEnabled_NoSidecar(t *testing.T) {
@@ -1405,11 +1405,12 @@ func TestBuildMasterJob_MetricsExporter_NoUserSecurityContext(t *testing.T) {
 
 	job := BuildMasterJob(lt, cfg, logr.Discard())
 
-	// Master job has 2 containers: locust + metrics exporter (OTel is disabled by default)
-	require.Len(t, job.Spec.Template.Spec.Containers, 2)
+	// Master job has 1 main container (locust); metrics exporter is now a native sidecar initContainer.
+	require.Len(t, job.Spec.Template.Spec.Containers, 1)
+	require.Len(t, job.Spec.Template.Spec.InitContainers, 1)
 
 	// Metrics exporter sidecar should have its own hardcoded security context, NOT the user's
-	metricsContainer := job.Spec.Template.Spec.Containers[1]
+	metricsContainer := job.Spec.Template.Spec.InitContainers[0]
 	assert.Equal(t, MetricsExporterContainerName, metricsContainer.Name)
 	require.NotNil(t, metricsContainer.SecurityContext, "Metrics exporter should have its own hardcoded security context")
 	// Verify it has the hardcoded values, not the user's AllowPrivilegeEscalation=false
@@ -1472,10 +1473,10 @@ func TestBuildMasterJob_ContainerSecurityOnly_PodGetsDefault(t *testing.T) {
 	assert.False(t, *locustContainer.SecurityContext.AllowPrivilegeEscalation)
 }
 
-func TestBuildMetricsExporterContainer_HasHardenedSecurityContext(t *testing.T) {
+func TestBuildMetricsExporterSidecar_HasHardenedSecurityContext(t *testing.T) {
 	cfg := newTestConfig()
 
-	container := buildMetricsExporterContainer(cfg)
+	container := buildMetricsExporterSidecar(cfg)
 
 	require.NotNil(t, container.SecurityContext)
 	require.NotNil(t, container.SecurityContext.AllowPrivilegeEscalation)
@@ -1484,6 +1485,23 @@ func TestBuildMetricsExporterContainer_HasHardenedSecurityContext(t *testing.T) 
 	assert.Equal(t, []corev1.Capability{"ALL"}, container.SecurityContext.Capabilities.Drop)
 	require.NotNil(t, container.SecurityContext.ReadOnlyRootFilesystem)
 	assert.True(t, *container.SecurityContext.ReadOnlyRootFilesystem)
+}
+
+// Regression guard: the metrics exporter must remain a native sidecar.
+// Dropping RestartPolicy: Always silently degrades it back to a one-shot init container,
+// which blocks Job completion and reintroduces the bug this PR fixes.
+func TestBuildMasterJob_MetricsExporterIsNativeSidecar(t *testing.T) {
+	lt := newTestLocustTest()
+	cfg := newTestConfig()
+
+	job := BuildMasterJob(lt, cfg, logr.Discard())
+
+	require.Len(t, job.Spec.Template.Spec.InitContainers, 1, "exporter must be in InitContainers")
+	exporter := job.Spec.Template.Spec.InitContainers[0]
+	assert.Equal(t, MetricsExporterContainerName, exporter.Name)
+	require.NotNil(t, exporter.RestartPolicy, "exporter must have RestartPolicy set")
+	assert.Equal(t, corev1.ContainerRestartPolicyAlways, *exporter.RestartPolicy,
+		"exporter must be a native sidecar (restartPolicy: Always); without this, the initContainer blocks Job completion")
 }
 
 func boolPtr(b bool) *bool {


### PR DESCRIPTION
## Problem

The metrics exporter runs as a regular sidecar container alongside the locust master. When the locust test completes, the metrics exporter continues running indefinitely, preventing the Job from completing.

This blocks detection of Job completion by the operator, which is needed for fixes like #326 (skip recovery for completed tests).

### Before (regular sidecar)

```
$ kubectl get jobs
NAME                     STATUS     COMPLETIONS   DURATION
test-sidecar-1-master    Running    0/1           5m
```

The Job never completes because the metrics exporter sidecar keeps running.

```
$ kubectl get pod test-sidecar-1-master-xxxxx -o jsonpath='{.status.containerStatuses[*].name}: {.status.containerStatuses[*].state}'
locust-master:           Terminated (exit code 0)
locust-metrics-exporter: Running    <-- blocks Job completion
```

## Solution

Convert the metrics exporter from a regular `container` to a native sidecar (Kubernetes 1.29+, KEP-753):

- Move it from `spec.containers` to `spec.initContainers` on the Master Pod.
- Set `restartPolicy: Always` on that initContainer — this is what makes it a *native sidecar* rather than a one-shot init step.
- Kubelet auto-terminates native sidecars once all main containers exit, so the Job completes cleanly.

## Result (after fix)

```
$ kubectl get locusttest
NAME            PHASE       WORKERS   AGE
test-sidecar.1  Succeeded   1         84s

$ kubectl get jobs
NAME                     STATUS     COMPLETIONS   DURATION
test-sidecar-1-master    Complete   1/1           76s
```

```
$ kubectl get pod test-sidecar-1-master-xxxxx -o jsonpath='{.status.containerStatuses[*].name}: {.status.containerStatuses[*].state}'
locust-master:           Terminated (exit code 0) - Completed
locust-metrics-exporter: Terminated (exit code 2) - terminated by k8s (expected)
```

The metrics exporter is automatically terminated by Kubernetes when the main locust container exits, allowing the Job to complete.

## Requirements

- **Kubernetes 1.29+** — native sidecar containers are off-by-default in 1.28 (alpha) and on-by-default from 1.29 (KEP-753). Chart `kubeVersion` bumped accordingly so `helm install` fails loudly on older clusters.

## Testing

Tested on GKE Autopilot cluster (k8s 1.32) with:
- 60s runtime tests
- Metrics exporter sidecar enabled
- Verified Job completes and LocustTest reaches Succeeded

## References

- [KEP-753: Sidecar Containers](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/753-sidecar-containers)
- [Kubernetes 1.29 Release Notes](https://kubernetes.io/blog/2023/12/14/kubernetes-v1-29-release/) — native sidecars graduated to beta + on-by-default
