### PR TITLE
fix(naming): make generated resource names a single source of truth

### DIFF
--- a/api/v2/locusttest_webhook.go
+++ b/api/v2/locusttest_webhook.go
@@ -256,9 +256,11 @@ func validateVolumeName(lt *LocustTest, name string) error {
 		return fmt.Errorf("volume name %q is reserved by the operator", name)
 	}
 
-	// Check for CR-based names
-	masterName := lt.Name + "-master"
-	workerName := lt.Name + "-worker"
+	// Check for CR-based names. These must be built with GeneratedNodeName —
+	// the operator names its ConfigMap volume after the sanitized node name, so
+	// comparing against the raw CR name misses the conflict for dotted CR names.
+	masterName := GeneratedNodeName(lt.Name, NodeModeMaster)
+	workerName := GeneratedNodeName(lt.Name, NodeModeWorker)
 	if name == masterName || name == workerName {
 		return fmt.Errorf("volume name %q conflicts with operator-generated name", name)
 	}

--- a/api/v2/locusttest_webhook_test.go
+++ b/api/v2/locusttest_webhook_test.go
@@ -449,6 +449,38 @@ func TestValidateVolumeName_WorkerConflict(t *testing.T) {
 	assert.Contains(t, err.Error(), "conflicts with operator-generated name")
 }
 
+// Regression test: the operator names its generated ConfigMap volume after the
+// sanitized node name, so for a dotted CR name the conflicting volume is
+// "my-test-v2-master", not "my-test.v2-master". Comparing against the raw CR
+// name let the real conflict through while rejecting a name that can never be
+// generated.
+func TestValidateVolumeName_DottedNameConflict(t *testing.T) {
+	lt := &LocustTest{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-test.v2", Namespace: "default"},
+	}
+
+	// The names the operator actually generates must be rejected.
+	err := validateVolumeName(lt, "my-test-v2-master")
+	require.Error(t, err, "sanitized master volume name must conflict")
+	assert.Contains(t, err.Error(), "conflicts with operator-generated name")
+
+	err = validateVolumeName(lt, "my-test-v2-worker")
+	require.Error(t, err, "sanitized worker volume name must conflict")
+	assert.Contains(t, err.Error(), "conflicts with operator-generated name")
+
+	// The raw, unsanitized names are never generated, so they are not conflicts.
+	assert.NoError(t, validateVolumeName(lt, "my-test.v2-master"))
+	assert.NoError(t, validateVolumeName(lt, "my-test.v2-worker"))
+}
+
+func TestGeneratedNodeName(t *testing.T) {
+	assert.Equal(t, "my-test-master", GeneratedNodeName("my-test", NodeModeMaster))
+	assert.Equal(t, "my-test-worker", GeneratedNodeName("my-test", NodeModeWorker))
+	assert.Equal(t, "team-a-load-test-master", GeneratedNodeName("team-a.load.test", NodeModeMaster))
+	assert.Equal(t, "no-dots-here", SanitizeResourceName("no-dots-here"))
+	assert.Equal(t, "a-b-c", SanitizeResourceName("a.b.c"))
+}
+
 func TestValidateVolumes_PathConflict(t *testing.T) {
 	lt := &LocustTest{
 		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},

--- a/api/v2/naming.go
+++ b/api/v2/naming.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Node mode suffixes used when generating resource names from a CR name.
+const (
+	// NodeModeMaster is the suffix for master-side generated resources.
+	NodeModeMaster = "master"
+	// NodeModeWorker is the suffix for worker-side generated resources.
+	NodeModeWorker = "worker"
+)
+
+// SanitizeResourceName converts a CR name into a form usable as a generated
+// Kubernetes resource name. CR names may contain dots (they are valid in
+// object names), but the operator's generated names — Services, Jobs, pod
+// labels, volume names — must not, so dots are replaced with dashes.
+func SanitizeResourceName(name string) string {
+	return strings.ReplaceAll(name, ".", "-")
+}
+
+// GeneratedNodeName returns the resource name the operator generates for a CR
+// name and node mode, e.g. ("team-a.load-test", NodeModeMaster) ->
+// "team-a-load-test-master".
+//
+// This is the single source of truth for generated resource names. Anything
+// that creates, looks up, or validates against those names must use it —
+// computing the name by hand caused a recovery loop for dotted CR names
+// (see the fix for issue #50).
+func GeneratedNodeName(crName, mode string) string {
+	return SanitizeResourceName(fmt.Sprintf("%s-%s", crName, mode))
+}

--- a/internal/controller/locusttest_controller.go
+++ b/internal/controller/locusttest_controller.go
@@ -330,6 +330,12 @@ func (r *LocustTestReconciler) handleExternalResourceDeletion(
 // checkResourcesExist verifies that all required resources (Service, Master Job, Worker Job) exist.
 // If any resource is missing, it handles external deletion recovery.
 // Returns (masterJob, workerJob, shouldRequeue, requeueAfter, error).
+//
+// Caveat: when the test is in a terminal phase, handleExternalResourceDeletion
+// skips recovery for missing resources and reports them as present, so the
+// returned Jobs may be zero-valued. Callers must not derive phase from them —
+// reconcileStatus relies on its own shouldSkipStatusUpdate check to return
+// before that happens. Keep that check in place if this is refactored.
 func (r *LocustTestReconciler) checkResourcesExist(
 	ctx context.Context,
 	lt *locustv2.LocustTest,

--- a/internal/controller/locusttest_controller_unit_test.go
+++ b/internal/controller/locusttest_controller_unit_test.go
@@ -94,6 +94,34 @@ func newTestOperatorConfig() *config.OperatorConfig {
 }
 
 // newTestLocustTestCR creates a test LocustTest CR.
+// drainEvents empties the recorder's buffered events so that later assertions
+// only observe events emitted after this point.
+func drainEvents(recorder *record.FakeRecorder) {
+	for {
+		select {
+		case <-recorder.Events:
+		default:
+			return
+		}
+	}
+}
+
+// assertNoResourceDeletedEvent drains every buffered event and fails if any of
+// them reports an external deletion. Draining all of them matters: a single
+// non-blocking read inspects only the first buffered event and would miss a
+// ResourceDeleted queued behind an unrelated one.
+func assertNoResourceDeletedEvent(t *testing.T, recorder *record.FakeRecorder, msg string) {
+	t.Helper()
+	for {
+		select {
+		case event := <-recorder.Events:
+			assert.NotContains(t, event, "ResourceDeleted", msg)
+		default:
+			return
+		}
+	}
+}
+
 func newTestLocustTestCR(name, namespace string) *locustv2.LocustTest {
 	return &locustv2.LocustTest{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1141,12 +1169,7 @@ func TestReconcile_DottedName_NoSpuriousRecovery(t *testing.T) {
 	require.NoError(t, err, "master Service should exist under the sanitized name")
 
 	// Drain creation events from first reconcile
-	for i := 0; i < 3; i++ {
-		select {
-		case <-recorder.Events:
-		default:
-		}
-	}
+	drainEvents(recorder)
 
 	// Mark the Jobs as actively running so status derivation keeps Running
 	for _, jobName := range []string{"my-test-v2-master", "my-test-v2-worker"} {
@@ -1172,12 +1195,8 @@ func TestReconcile_DottedName_NoSpuriousRecovery(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, time.Duration(0), result.RequeueAfter, "healthy test should not trigger recovery requeue")
 
-	select {
-	case event := <-recorder.Events:
-		assert.NotContains(t, event, "ResourceDeleted",
-			"healthy dotted-name test must not be treated as externally deleted")
-	default:
-	}
+	assertNoResourceDeletedEvent(t, recorder,
+		"healthy dotted-name test must not be treated as externally deleted")
 
 	// Phase must remain Running, not be reset to Pending
 	err = reconciler.Get(ctx, types.NamespacedName{
@@ -1207,12 +1226,7 @@ func TestReconcile_TerminalPhase_SkipsRecoveryAfterCleanup(t *testing.T) {
 	require.NoError(t, err)
 
 	// Drain creation events from first reconcile
-	for i := 0; i < 3; i++ {
-		select {
-		case <-recorder.Events:
-		default:
-		}
-	}
+	drainEvents(recorder)
 
 	// Simulate a completed test
 	err = reconciler.Get(ctx, types.NamespacedName{
@@ -1243,12 +1257,8 @@ func TestReconcile_TerminalPhase_SkipsRecoveryAfterCleanup(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, ctrl.Result{}, result, "terminal test should not requeue")
 
-	select {
-	case event := <-recorder.Events:
-		assert.NotContains(t, event, "ResourceDeleted",
-			"terminal-phase cleanup must not be treated as external deletion")
-	default:
-	}
+	assertNoResourceDeletedEvent(t, recorder,
+		"terminal-phase cleanup must not be treated as external deletion")
 
 	// Phase must remain Succeeded and resources must not be recreated
 	err = reconciler.Get(ctx, types.NamespacedName{

--- a/internal/resources/labels.go
+++ b/internal/resources/labels.go
@@ -18,7 +18,6 @@ package resources
 
 import (
 	"fmt"
-	"strings"
 
 	locustv2 "github.com/AbdelrhmanHamouda/locust-k8s-operator/api/v2"
 	"github.com/AbdelrhmanHamouda/locust-k8s-operator/internal/config"
@@ -27,9 +26,11 @@ import (
 // NodeName constructs the node name from the CR name and operational mode.
 // Format: "{cr-name}-{mode}" with dots replaced by dashes.
 // Example: "team-a.load-test" -> "team-a-load-test-master"
+//
+// Delegates to locustv2.GeneratedNodeName so that name generation, lookup and
+// webhook validation all derive names from one implementation.
 func NodeName(crName string, mode OperationalMode) string {
-	name := fmt.Sprintf("%s-%s", crName, mode.String())
-	return strings.ReplaceAll(name, ".", "-")
+	return locustv2.GeneratedNodeName(crName, mode.String())
 }
 
 // BuildLabels constructs the labels for a pod based on the LocustTest CR and mode.

--- a/internal/resources/types.go
+++ b/internal/resources/types.go
@@ -16,14 +16,18 @@ limitations under the License.
 
 package resources
 
+import (
+	locustv2 "github.com/AbdelrhmanHamouda/locust-k8s-operator/api/v2"
+)
+
 // OperationalMode represents the mode of operation for a Locust node.
 type OperationalMode string
 
 const (
 	// Master represents the master node mode.
-	Master OperationalMode = "master"
+	Master OperationalMode = locustv2.NodeModeMaster
 	// Worker represents the worker node mode.
-	Worker OperationalMode = "worker"
+	Worker OperationalMode = locustv2.NodeModeWorker
 )
 
 // String returns the string representation of the OperationalMode.


### PR DESCRIPTION
Follow-up to #326 (now merged). Rebased onto `master`; this PR is a single commit.

## Problem

#326 fixed a recovery loop caused by two places computing an operator-generated resource name differently. The same drift existed in the webhook, unfixed.

`validateVolumeName` built the conflicting names by hand:

```go
masterName := lt.Name + "-master"
workerName := lt.Name + "-worker"
```

But the operator names its generated ConfigMap volume after the **sanitized** node name (`internal/resources/job.go`, `Name: nodeName`). For a dotted CR name like `my-test.v2` this is wrong in both directions:

- it compares against `my-test.v2-master` — a name the operator can never generate — so it rejects a volume name that is actually safe;
- and it lets `my-test-v2-master` through, which is exactly the name the operator *will* generate, producing a duplicate volume name in the pod spec.

Same class of bug as #326: one naming rule, implemented twice.

## Fix

Add `api/v2/naming.go` with the single implementation of the rule:

```go
func SanitizeResourceName(name string) string
func GeneratedNodeName(crName, mode string) string
```

It lives in `api/v2`, not `internal/resources`, because `internal/resources` already imports `api/v2` — the reverse import would be an import cycle.

Everything now derives from it:

- `resources.NodeName` delegates to `v2.GeneratedNodeName` (behaviour unchanged).
- `resources.Master` / `resources.Worker` reference the shared `NodeModeMaster` / `NodeModeWorker` suffixes.
- `validateVolumeName` uses `GeneratedNodeName`.

No hand-rolled copy of the rule remains, which closes the bug class rather than this one instance.

## Review nits from #326

- **`checkResourcesExist` contract.** In a terminal phase the terminal-state guard reports missing resources as present, so the returned Jobs can be zero-valued. Nothing bad happens today only because `reconcileStatus` re-checks `shouldSkipStatusUpdate` immediately after and returns before those Jobs reach `updateStatusFromJobs`. That coupling is easy to break in a refactor and was undocumented; it now is.
- **Weak event assertions.** The two controller tests added in #326 used a single non-blocking `select` read, which inspects only the *first* buffered event — a `ResourceDeleted` queued behind an unrelated event would have been missed. Replaced with `drainEvents` / `assertNoResourceDeletedEvent` helpers that drain every buffered event.

## Tests

- `TestValidateVolumeName_DottedNameConflict` — asserts the sanitized names conflict and the raw dotted names do not. **Verified to fail against the old raw-name check** (`An error is expected but got nil`) and pass with the fix.
- `TestGeneratedNodeName` — covers the helper directly, including multi-dot names.
- Existing webhook conflict tests use non-dotted names, where sanitized == raw, so they are unaffected.

## Verification

- `go build ./...`, `go vet ./...` — clean
- `make lint` — **0 issues**
- `./api/...`, `./internal/resources/...`, `./internal/controller/...` unit suites — all pass
- envtest/Ginkgo suite not run locally (no `etcd` in `/usr/local/kubebuilder/bin`); leaving that to CI

## Not addressed

The TTL race @BackSlasher raised on #326 — operator down when a test completes, master Job TTL-GC'd before `Succeeded` persists, restart sees a `Running` test with genuinely-missing resources and re-runs it. Not closable without persisting completion evidence independently of the Job. Worth its own issue. Note `JOB_TTL_SECONDS_AFTER_FINISHED` is opt-in (nil default), but `TTL=0` is accepted and makes it a live race even with the operator up — a docs warning against very low TTLs may be worthwhile.