### PR TITLE
test(e2e): wait for the webhook to serve, not just for an endpoint

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -20,7 +20,9 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -91,6 +93,15 @@ var _ = BeforeSuite(func() {
 	By("waiting for the webhook service endpoint to be ready")
 	err = utils.WaitForWebhookReady("locust-k8s-operator-system", "locust-k8s-operator-webhook-service", "2m")
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Webhook service endpoint not ready")
+
+	// An endpoint address only means the pod passed its readiness probe on the
+	// health port; the webhook's TLS listener starts separately. Probe the
+	// admission path itself so specs cannot race the webhook coming up.
+	By("waiting for the webhook to serve admission requests")
+	probeManifest, err := filepath.Abs(filepath.Join("testdata", "v2", "locusttest-basic.yaml"))
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to resolve webhook probe manifest")
+	err = utils.WaitForWebhookServing("locust-k8s-operator-system", probeManifest, 2*time.Minute)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Webhook not serving admission requests")
 })
 
 var _ = AfterSuite(func() {

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -388,7 +388,11 @@ func WaitForControllerReady(namespace string, timeout string) error {
 	return err
 }
 
-// WaitForWebhookReady waits for the webhook service endpoint to be ready
+// WaitForWebhookReady waits for the webhook service endpoint to be ready.
+//
+// Note that this only proves an Endpoints address exists. It is a necessary but
+// not sufficient precondition for sending admission requests — use
+// WaitForWebhookServing for that.
 func WaitForWebhookReady(namespace, serviceName string, timeout string) error {
 	_, _ = fmt.Fprintf(GinkgoWriter, "Waiting for webhook service endpoint to be ready...\n")
 	//nolint:gosec // G204 - test helper, args are controlled
@@ -398,6 +402,91 @@ func WaitForWebhookReady(namespace, serviceName string, timeout string) error {
 		"--timeout", timeout)
 	_, err := Run(cmd)
 	return err
+}
+
+// webhookUnavailableMarkers are the errors the API server reports when it cannot
+// get an admission response from the webhook, as opposed to the webhook
+// answering with a rejection. These are transient during startup.
+var webhookUnavailableMarkers = []string{
+	"connection refused",       // TLS listener not accepting yet
+	"connection reset by peer", // listener came up mid-handshake
+	"no endpoints available",   // Service has no ready backend yet
+	"tls: internal error",      // serving cert not injected yet
+	"context deadline exceeded",
+	"i/o timeout",
+	"EOF",
+}
+
+// isWebhookUnavailable reports whether err is the API server failing to get an
+// admission response from the webhook, rather than the webhook answering.
+//
+// A rejection is a definitive answer and must never be retried. Errors that are
+// not about reaching the webhook at all — schema validation, a bad manifest path
+// — are not startup races either. Only a failure to call the webhook with a
+// transport cause we recognise is treated as transient; an unrecognised cause
+// fails fast rather than burning the whole timeout.
+func isWebhookUnavailable(err error) bool {
+	msg := err.Error()
+
+	// The webhook answered and rejected the object.
+	if strings.Contains(msg, "denied the request") {
+		return false
+	}
+	// Not a failure to reach the webhook.
+	if !strings.Contains(msg, "failed calling webhook") &&
+		!strings.Contains(msg, "failed to call webhook") {
+		return false
+	}
+	for _, marker := range webhookUnavailableMarkers {
+		if strings.Contains(msg, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// WaitForWebhookServing waits until the webhook actually answers admission
+// requests for the object in the given manifest.
+//
+// WaitForWebhookReady is not enough on its own: an Endpoints address appears as
+// soon as the manager pod passes its readiness probe on the health port, but
+// controller-runtime starts the webhook's TLS listener separately. That leaves a
+// window in which the pod is Ready, the Service has an endpoint, and the webhook
+// port still refuses connections — so a spec that applies a CR right after
+// WaitForWebhookReady can fail with "failed calling webhook: connect: connection
+// refused".
+//
+// Driving a server-side dry-run through the admission chain is what actually
+// proves the webhook is serving: it issues a real CREATE admission request and
+// persists nothing.
+//
+// Only connection-level failures are retried. Any other error — a genuine
+// rejection or a misconfigured webhook — is returned immediately, so a real
+// problem surfaces as itself instead of as a timeout.
+func WaitForWebhookServing(namespace, path string, timeout time.Duration) error {
+	_, _ = fmt.Fprintf(GinkgoWriter, "Waiting for webhook to serve admission requests...\n")
+
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for {
+		//nolint:gosec // G204 - test helper, args are controlled
+		cmd := exec.Command("kubectl", "apply", "-f", path,
+			"-n", namespace,
+			"--dry-run=server")
+		_, err := Run(cmd)
+		if err == nil {
+			return nil
+		}
+		if !isWebhookUnavailable(err) {
+			return err
+		}
+		lastErr = err
+
+		if time.Now().After(deadline) {
+			return fmt.Errorf("webhook did not start serving admission requests within %s: %w", timeout, lastErr)
+		}
+		time.Sleep(2 * time.Second)
+	}
 }
 
 // WaitForCertificateReady waits for the serving certificate to be ready

--- a/test/utils/utils_test.go
+++ b/test/utils/utils_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"errors"
+	"testing"
+)
+
+// isWebhookUnavailable decides whether WaitForWebhookServing retries or fails
+// fast. Misclassifying in either direction is harmful: treating a real rejection
+// as transient turns a clear error into a timeout, and treating a startup race
+// as fatal reintroduces the flake the probe exists to remove.
+func TestIsWebhookUnavailable(t *testing.T) {
+	tests := []struct {
+		name string
+		err  string
+		want bool
+	}{
+		{
+			name: "TLS listener not up yet",
+			err: `"kubectl apply -f x.yaml -n ns --dry-run=server" failed with error ` +
+				`"Error from server (InternalError): Internal error occurred: failed calling webhook ` +
+				`\"vlocusttest-v2.kb.io\": failed to call webhook: Post \"https://svc:443/validate\": ` +
+				`dial tcp 10.96.219.7:443: connect: connection refused"`,
+			want: true,
+		},
+		{
+			name: "listener came up mid-handshake",
+			err:  `failed calling webhook: Post "https://svc:443/validate": read tcp: connection reset by peer`,
+			want: true,
+		},
+		{
+			name: "service has no ready backend",
+			err:  `failed calling webhook "vlocusttest-v2.kb.io": no endpoints available for service "webhook-service"`,
+			want: true,
+		},
+		{
+			name: "serving certificate not injected yet",
+			err:  `failed calling webhook: Post "https://svc:443/validate": remote error: tls: internal error`,
+			want: true,
+		},
+		{
+			name: "webhook answered with a rejection",
+			err: `"kubectl apply -f x.yaml" failed with error "Error from server (Forbidden): ` +
+				`admission webhook \"vlocusttest-v2.kb.io\" denied the request: ` +
+				`volume name \"my-test-master\" conflicts with operator-generated name"`,
+			want: false,
+		},
+		{
+			name: "schema validation rejection",
+			err:  `Error from server (BadRequest): spec.worker.replicas in body should be greater than or equal to 1`,
+			want: false,
+		},
+		{
+			name: "manifest missing",
+			err:  `error: the path "testdata/v2/locusttest-basic.yaml": no such file or directory`,
+			want: false,
+		},
+		{
+			name: "unrecognised transport cause fails fast rather than burning the timeout",
+			err:  `failed calling webhook "vlocusttest-v2.kb.io": something entirely unexpected`,
+			want: false,
+		},
+		{
+			name: "transport marker outside a webhook-call error is not a webhook race",
+			err:  `Unable to connect to the server: dial tcp 127.0.0.1:6443: connect: connection refused`,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isWebhookUnavailable(errors.New(tt.err)); got != tt.want {
+				t.Errorf("isWebhookUnavailable() = %v, want %v\nerror: %s", got, tt.want, tt.err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes the intermittent E2E failure that turned up on #341. Independent of that PR — branched off `master`.

## The flake

`Validation Webhook / should accept valid CR` fails with:

```
failed calling webhook "vlocusttest-v2.kb.io": failed to call webhook:
Post "https://locust-k8s-operator-webhook-service.../validate-locust-io-v2-locusttest":
dial tcp 10.96.219.7:443: connect: connection refused
```

Note what this is *not*: it is not the webhook rejecting the CR. Nothing is listening on the webhook port yet.

## Root cause

The suite's readiness gate proves the wrong thing. `WaitForWebhookReady` waits for `endpoints/<svc>` to have an address IP:

```go
kubectl wait endpoints <svc> --for=jsonpath={.subsets[0].addresses[0].ip}
```

That address appears as soon as the manager pod passes its **readiness probe on the health port**. controller-runtime starts the **webhook's TLS listener on :9443 separately**. So there is a window where the pod is Ready, the Service has an endpoint, and the webhook port still refuses connections.

The timeline in the observed failure confirms it: the webhook refused at `14:04:16`, then served a CR normally at `14:04:26`.

Only one spec is exposed to this. The sibling spec (`should reject CR with invalid workerReplicas (0)`) is satisfied by CRD schema validation (`Minimum=1`) at the API server and never reaches the webhook — which is why the suite mostly looks fine and this surfaces as a one-spec flake.

## Fix

Add `WaitForWebhookServing`, which drives a server-side dry-run through the admission chain until it succeeds:

```go
kubectl apply -f <valid CR> -n <ns> --dry-run=server
```

That issues a real CREATE admission request and persists nothing, so it proves the webhook is *answering* rather than that a backend address exists.

This probe is meaningful because the webhook is registered `failurePolicy=fail` — if it cannot be reached, the dry-run errors instead of silently passing. (With `Ignore` the probe would be worthless.)

`WaitForWebhookReady` is kept as the cheap precondition and its doc comment now says what it does and does not prove.

## Retry classification

Deliberately narrow, so this hardens the gate instead of hiding failures:

| Error | Behaviour |
|---|---|
| `failed calling webhook` + recognised transport cause (`connection refused`, `connection reset by peer`, `no endpoints available`, `tls: internal error`, timeouts, `EOF`) | retry |
| `denied the request` | **fail fast** — the webhook answered |
| schema validation, bad manifest path | **fail fast** — not a reachability problem |
| `failed calling webhook` + unrecognised cause | **fail fast** — don't burn the 2m timeout |

A transport marker alone is not enough; it must occur inside a webhook-call error. Otherwise something like `Unable to connect to the server: ... connection refused` (cluster gone) would be retried as if it were a webhook race.

On timeout the error wraps the last observed failure, so the cause is still visible.

## Tests

`TestIsWebhookUnavailable` — 9 cases covering each row above, including the two the distinction exists for: a rejection, and a transport error outside a webhook-call error. Both must not be retried.

This is the first test file under `test/utils/`.

## Verification

- `go build ./...`, `go vet ./...` — clean
- `make lint` — **0 issues**
- `go test ./test/utils/...` — 9/9 pass
- The E2E suite itself is validated by CI on this PR; that run is the real check on the gate, since the race cannot be reproduced on demand locally.

## Verification in CI — the race reproduced and was absorbed

The E2E run on this PR caught the race live. Timeline from the log:

| Time | Event |
|---|---|
| `18:41:08.752` | endpoint gate cleared (took under 200ms) |
| `18:41:08.904` | probe attempt 1 — **failed**, webhook not serving yet |
| `18:41:10.971` | probe attempt 2 — succeeded |
| `18:41:11.032` | suite proceeded |

Exactly 2 attempts, then `26 of 26 Specs ... SUCCESS! -- 26 Passed | 0 Failed`.

This is stronger than a green run. The first admission request genuinely failed, which shows the failure window is real and that the old gate would have released the suite straight into it — the endpoint check cleared and the webhook still was not answering ~200ms later. Cost of the new gate in this run: ~2.1 seconds.
