### PR TITLE
ci: run E2E on every pull request so the required check reports

### DIFF
--- a/.github/workflows/go-test-e2e.yml
+++ b/.github/workflows/go-test-e2e.yml
@@ -1,6 +1,10 @@
 name: 🚀 Go E2E Tests
 
 on:
+  # On master the path filter is a pure cost saving: nothing gates on the
+  # result, so runs that cannot be affected by the change are skipped.
+  # '.github/workflows/**' is included because a change to this file or to
+  # ci.yaml can itself break the E2E run.
   push:
     branches: [main, master]
     paths:
@@ -11,15 +15,15 @@ on:
       - 'go.mod'
       - 'go.sum'
       - 'Makefile'
+      - '.github/workflows/**'
+      - '.github/kind-config.yaml'
+  # Deliberately NOT path-filtered. '🎯 Run E2E Tests' is a required status
+  # check on master, and GitHub blocks a pull request whose required check is
+  # expected but never reported. A filtered trigger therefore makes every
+  # pull request outside those paths permanently unmergeable rather than
+  # merely unverified: docs-only, chart-only, workflow-only, and every
+  # Dependabot action bump. A required check has to run on everything it gates.
   pull_request:
-    paths:
-      - 'cmd/**'
-      - 'api/**'
-      - 'internal/**'
-      - 'test/**'
-      - 'go.mod'
-      - 'go.sum'
-      - 'Makefile'
 
 permissions: read-all
 

--- a/README.md
+++ b/README.md
@@ -20,28 +20,6 @@ Docs: [github.io/locust-k8s-operator/](https://abdelrhmanhamouda.github.io/locus
 
 -----------------------------
 
-## v2.0 - Complete Go Rewrite
-
-The operator has been completely rewritten in Go, bringing significant improvements:
-
-| Improvement   | Before (Java)     | After (Go)          |
-|---------------|-------------------|---------------------|
-| **Memory**    | ~256MB            | ~64MB               |
-| **Startup**   | ~60s              | <1s                 |
-| **Framework** | Java Operator SDK | Operator SDK / controller-runtime |
-
-### New Features in v2.0
-
-- **Native OpenTelemetry** - Export traces and metrics directly with `--otel` flag
-- **Secret & ConfigMap Injection** - Securely inject credentials as env vars or file mounts
-- **Volume Mounting** - Mount PVCs, ConfigMaps, Secrets with target filtering (master/worker/both)
-- **Separate Resource Specs** - Independent resource configuration for master and worker pods
-- **Enhanced Status** - Phase tracking, conditions, and worker connection status
-
-**[Migration Guide](https://abdelrhmanhamouda.github.io/locust-k8s-operator/migration/)** for existing v1 users
-
------------------------------
-
 [//]: # (Badges)
 [![CI Pipeline][pipeline-status]][pipeline-status-url]
 [![Security Scan][security-scan]][security-scan-url]
@@ -56,6 +34,20 @@ The operator has been completely rewritten in Go, bringing significant improveme
 
 The Operator is designed to unlock seamless and effortless distributed performance testing in the cloud and enable continuous integration for CI/CD. By design, the entire system is cloud native and focuses on automation and CI practices. One strong feature about the system is its ability to horizontally scale to meet any required performance demands.
 
+You describe a load test as a `LocustTest` custom resource. The operator creates the master and worker pods, wires them together, streams the results wherever you point them, and cleans everything up when the run finishes.
+
+## What You Get
+
+**Observability.** Export traces and metrics straight out of Locust with native OpenTelemetry, no sidecar involved. Prometheus scraping works out of the box for setups that aren't on OTLP yet.
+
+**Control over placement.** Node affinity, taint tolerations, node selectors, and `runtimeClassName` for sandboxed runtimes such as gVisor or Kata Containers. Master and worker pods take independent resource specs, and CPU limits can be lifted entirely for latency-sensitive runs.
+
+**Everything your test needs at runtime.** Inject credentials from Secrets and ConfigMaps as environment variables or file mounts. Mount test data and certificates from PVCs, ConfigMaps, or Secrets, targeted at the master, the workers, or both. Private registries are supported through `imagePullSecrets`.
+
+**Kafka and AWS MSK** integration for testing event-driven systems, with authentication handled for you.
+
+Tests run in isolation, so you can run many at once without cross-interference, and a configurable TTL tears down resources once a run is done. The [features page](https://abdelrhmanhamouda.github.io/locust-k8s-operator/features/) covers the full list.
+
 ## Documentation
 
 All documentation for this project is available at [github.io/locust-k8s-operator/](https://abdelrhmanhamouda.github.io/locust-k8s-operator/).
@@ -64,11 +56,9 @@ All documentation for this project is available at [github.io/locust-k8s-operato
 
 ### Prerequisites
 
-- **Go 1.26+** for local development
-- **Docker** for building container images
-- **kubectl** configured for your cluster
-- **Helm 3.x** for chart installation
-- **Kind** (optional, for local E2E testing)
+Kubernetes **1.29 or newer**, and Helm 3.x to install the chart.
+
+For local development you'll also want Go 1.26+, Docker for building images, kubectl pointed at your cluster, and Kind if you plan to run the E2E suite.
 
 ### Installation
 
@@ -84,6 +74,8 @@ Or from the repository:
 ```bash
 helm install locust-operator charts/locust-k8s-operator/
 ```
+
+Already running `locust.io/v1` resources? They keep working through the conversion webhook, and the [migration guide](https://abdelrhmanhamouda.github.io/locust-k8s-operator/migration/) walks through moving to `v2`. The v1 API is deprecated and slated for removal in v3.
 
 ### Development
 


### PR DESCRIPTION
## The bug

`🎯 Run E2E Tests` is a **required** status check on `master`, but `go-test-e2e.yml` was path-filtered to `cmd/`, `api/`, `internal/`, `test/`, `go.mod`, `go.sum`, `Makefile`.

GitHub blocks a pull request whose required check is *expected but never reported*. So any PR touching none of those paths could never merge, no matter how green it looked:

- docs-only changes
- chart-only changes
- workflow-only changes
- **every Dependabot GitHub Action bump** (#352, #353, #354, #355, #356)

That is why those PRs sat `BLOCKED` while `gh pr checks` showed everything they ran as passing. #354 is a worked example: rebased onto current master, approved, `mergeable: MERGEABLE`, three of four required checks green, and still `mergeStateStatus: BLOCKED`, because the fourth simply never reported.

This is separate from the Codacy failure fixed in #361. That one removed a check that was *failing*; this one is a check that is *missing*, which blocks in a different way and was still in force afterwards.

## The fix

A required check cannot be conditional, so the `pull_request` trigger is no longer path-filtered. Every PR now runs E2E and every PR can report the check it is gated on.

The `push` filter on `master` is kept, since nothing gates on that result and skipping unaffected runs is a pure cost saving. It gains `.github/workflows/**` and `.github/kind-config.yaml`, because a change to either can break the E2E run and currently ships untested.

Cost: roughly six minutes of E2E on PRs that previously skipped it. That is the price of the check actually being a gate.

## Also in this PR

`docs(readme)`: the `v2.0 - Complete Go Rewrite` section is retired. It sat above the badges and the hero image, so the first thing a visitor read was a migration note about a rewrite that is now just how the project is built, fronted by a Java-versus-Go memory and startup table that means nothing to someone arriving today.

Its feature list was worth keeping, so it is rewritten as present-tense capabilities and expanded from `docs/features.md`. Prerequisites now state the Kubernetes 1.29 floor, which the chart has enforced via `kubeVersion` since the native sidecar change but the README never mentioned. The migration guide link moves under Installation for v1 users, noting that v1 removal is planned for v3.

## After this merges

#352, #353, #354, #355 and #356 need a rebase, after which E2E will actually run on them and they can merge through the normal gate instead of needing an admin override. #354 is already rebased and approved and only needs the rebase onto this fix.

https://claude.ai/code/session_01QNEWDpJaFLYAQEuU3tSXz3
